### PR TITLE
test: release automation with version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,3 +739,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [DeepSeek](https://www.deepseek.com/) for DeepSeek API
 - [Google](https://cloud.google.com/text-to-speech) for Gemini and Cloud TTS
 - [AWS Polly](https://aws.amazon.com/polly/) for Text-to-Speech service
+# Test release automation


### PR DESCRIPTION
Testing the automated release workflow that will:
- Detect the `feat:` prefix in this commit
- Bump the version from 0.1.0 → 0.2.0 (minor bump)
- Create a git tag v0.2.0
- Generate a GitHub Release automatically

This PR demonstrates the release automation in action. When merged to main, the release workflow should trigger and handle all the version management automatically.