### PR TITLE
fix: release workflow checks tag existence instead of version match

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,133 +29,116 @@ jobs:
         id: commits
         run: |
           LAST_TAG=${{ steps.last_tag.outputs.tag }}
-          # Check if tag exists, if not get all commits
-          # Use %B to get full commit message (subject + body) to capture breaking markers and footers
           if git rev-parse ${LAST_TAG} >/dev/null 2>&1; then
             git log ${LAST_TAG}..HEAD --format='%B%n---COMMIT_SEP---%n' > /tmp/commits_full.txt
+            git log ${LAST_TAG}..HEAD --format='%s' > /tmp/subjects.txt
           else
             git log --format='%B%n---COMMIT_SEP---%n' > /tmp/commits_full.txt
+            git log --format='%s' > /tmp/subjects.txt
           fi
 
-          # Extract just subjects for display in release notes
-          git log --format='%s' > /tmp/subjects.txt 2>/dev/null || echo "" > /tmp/subjects.txt
+          # Check if there are any new commits
+          COMMIT_COUNT=$(wc -l < /tmp/subjects.txt | tr -d ' ')
+          echo "count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
 
-          # Store list for use in GitHub release
           {
             echo 'list<<EOF'
             cat /tmp/subjects.txt
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 
-          # Check for commit types in full commit messages
-          # HAS_FEAT: detects "feat:" and "feat!:" (breaking feature) at line start
-          HAS_FEAT=$(grep -E '^feat[!]*:' /tmp/commits_full.txt | wc -l)
-          # HAS_BREAKING: detects breaking changes
-          # - Lines starting with type!: (feat!:, fix!:, etc.)
-          # - Lines containing BREAKING CHANGE: or BREAKING_CHANGE:
-          HAS_BREAKING=$(grep -E '(^[a-z]+!:|BREAKING[[:space:]_]CHANGE:)' /tmp/commits_full.txt | wc -l)
+          HAS_FEAT=$(grep -cE '^feat[!]*:' /tmp/commits_full.txt || true)
+          HAS_BREAKING=$(grep -cE '(^[a-z]+!:|BREAKING[[:space:]_]CHANGE:)' /tmp/commits_full.txt || true)
           echo "has_feat=$HAS_FEAT" >> $GITHUB_OUTPUT
           echo "has_breaking=$HAS_BREAKING" >> $GITHUB_OUTPUT
 
-      - name: Determine version bump
+      - name: Determine version
         id: version
+        if: steps.commits.outputs.count != '0'
         run: |
           LAST_TAG="${{ steps.last_tag.outputs.tag }}"
-          CURRENT_VERSION="${LAST_TAG#v}"
+          CURRENT_TOML=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+          LAST_TAG_VERSION="${LAST_TAG#v}"
           HAS_FEAT=${{ steps.commits.outputs.has_feat }}
           HAS_BREAKING=${{ steps.commits.outputs.has_breaking }}
 
-          # Check if this is the first release (no tags exist)
           if [ "$LAST_TAG" = "v0.0.0" ]; then
-            # First release - start at 0.1.0
-            NEW_VERSION="0.1.0"
+            COMPUTED_VERSION="0.1.0"
             BUMP="initial"
           else
-            # Determine bump type based on commit analysis
             BUMP="patch"
-
             if [ "${HAS_BREAKING}" != "0" ]; then
               BUMP="major"
             elif [ "${HAS_FEAT}" != "0" ]; then
               BUMP="minor"
             fi
 
-            # Parse current version
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-            MAJOR=${MAJOR:-0}
-            MINOR=${MINOR:-0}
-            PATCH=${PATCH:-0}
-
-            # Bump version
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_TAG_VERSION"
             if [ "$BUMP" = "major" ]; then
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
+              MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
             elif [ "$BUMP" = "minor" ]; then
-              MINOR=$((MINOR + 1))
-              PATCH=0
+              MINOR=$((MINOR + 1)); PATCH=0
             else
               PATCH=$((PATCH + 1))
             fi
-
-            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+            COMPUTED_VERSION="$MAJOR.$MINOR.$PATCH"
           fi
 
+          # Use the higher of pyproject.toml version and computed version
+          # This handles cases where version was manually bumped in a PR
+          pick_higher() {
+            IFS='.' read -r a1 b1 c1 <<< "$1"
+            IFS='.' read -r a2 b2 c2 <<< "$2"
+            if [ "$a1" -gt "$a2" ] || \
+               { [ "$a1" -eq "$a2" ] && [ "$b1" -gt "$b2" ]; } || \
+               { [ "$a1" -eq "$a2" ] && [ "$b1" -eq "$b2" ] && [ "$c1" -gt "$c2" ]; }; then
+              echo "$1"
+            else
+              echo "$2"
+            fi
+          }
+
+          NEW_VERSION=$(pick_higher "$CURRENT_TOML" "$COMPUTED_VERSION")
           NEW_TAG="v$NEW_VERSION"
+
+          # Check if this tag already exists
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Tag $NEW_TAG already exists, skipping release"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
 
           echo "bump=$BUMP" >> $GITHUB_OUTPUT
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          echo "needs_toml_update=$( [ "$CURRENT_TOML" != "$NEW_VERSION" ] && echo true || echo false )" >> $GITHUB_OUTPUT
 
-          echo "Version bump: $BUMP"
-          echo "New version: $NEW_VERSION"
-
-      - name: Check if version changed
-        id: check_version
-        run: |
-          CURRENT=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-
-          if [ "$CURRENT" != "$NEW_VERSION" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "Current version: $CURRENT"
-            echo "New version: $NEW_VERSION"
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No version change needed"
-          fi
+          echo "Version: $NEW_VERSION (tag: $NEW_TAG, bump: $BUMP)"
+          echo "pyproject.toml: $CURRENT_TOML, needs update: $( [ "$CURRENT_TOML" != "$NEW_VERSION" ] && echo yes || echo no )"
 
       - name: Update version in pyproject.toml
-        if: steps.check_version.outputs.changed == 'true'
+        if: steps.version.outputs.skip == 'false' && steps.version.outputs.needs_toml_update == 'true'
         run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" pyproject.toml
-          echo "Updated pyproject.toml to version $NEW_VERSION"
+          sed -i "s/^version = .*/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
 
-      - name: Configure git
-        if: steps.check_version.outputs.changed == 'true'
+      - name: Commit version bump
+        if: steps.version.outputs.skip == 'false' && steps.version.outputs.needs_toml_update == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit version bump
-        if: steps.check_version.outputs.changed == 'true'
-        run: |
           git add pyproject.toml
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
-
-      - name: Create git tag
-        if: steps.check_version.outputs.changed == 'true'
-        run: |
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
           git push origin main
-          git push origin "${{ steps.version.outputs.tag }}"
 
-      - name: Create GitHub release
-        if: steps.check_version.outputs.changed == 'true'
+      - name: Create tag and release
+        if: steps.version.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "Release ${{ steps.version.outputs.version }}" \
             --notes "## Changes in this release


### PR DESCRIPTION
## Summary
- The release workflow was comparing `pyproject.toml` version against the auto-computed version and skipping when they matched
- Since PR #23 manually bumped the version to 0.2.0, the workflow saw no difference and skipped — no tag, no release, no PyPI publish
- Now the workflow checks whether the **git tag** already exists instead, and picks the higher of `pyproject.toml` version vs auto-computed version
- Also handles the case where `pyproject.toml` doesn't need updating (version already correct) but the tag/release still needs creating

## Test plan
- [ ] Merge this PR → release workflow should create tag `v0.2.0` and GitHub release
- [ ] GitHub release triggers publish workflow → package published to PyPI as `audify-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)