### PR TITLE
fix: configure git identity before tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
           echo "Version: $NEW_VERSION (tag: $NEW_TAG, bump: $BUMP)"
           echo "pyproject.toml: $CURRENT_TOML, needs update: $( [ "$CURRENT_TOML" != "$NEW_VERSION" ] && echo yes || echo no )"
 
+      - name: Configure git
+        if: steps.version.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Update version in pyproject.toml
         if: steps.version.outputs.skip == 'false' && steps.version.outputs.needs_toml_update == 'true'
         run: |
@@ -125,8 +131,6 @@ jobs:
       - name: Commit version bump
         if: steps.version.outputs.skip == 'false' && steps.version.outputs.needs_toml_update == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
           git push origin main


### PR DESCRIPTION
## Summary
- `git tag -a` requires a committer identity (user.name/user.email)
- The git config was only set inside the "Commit version bump" step, which is skipped when `pyproject.toml` already has the correct version (our case with v0.2.0)
- Moved git config to its own step that runs whenever a release will be created

This is the fix for the `Committer identity unknown` error in the v0.2.0 release attempt.

## Test plan
- [ ] Merge → release workflow creates tag `v0.2.0` + GitHub release
- [ ] GitHub release triggers publish workflow → `audify-cli` published to PyPI