### PR TITLE
fix(kokoro): handle new {id,name} voices shape from Kokoro-FastAPI v0.4.0

### DIFF
--- a/audify/convert.py
+++ b/audify/convert.py
@@ -28,7 +28,9 @@ def get_available_models_and_voices():
         )
         voices_response.raise_for_status()
         voices_data = voices_response.json().get("voices", [])
-        voices = sorted(voices_data)
+        # Kokoro-FastAPI v0.4.0+ returns [{"id": "...", "name": "..."}];
+        # earlier versions returned plain strings.
+        voices = sorted(v["id"] if isinstance(v, dict) else v for v in voices_data)
         return models, voices
 
     try:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -544,6 +544,36 @@ class TestGetAvailableModelsAndVoices:
         assert voices == ["af_alloy", "af_bella", "en_voice"]
         assert mock_get.call_count == 2
 
+    @patch("requests.get")
+    def test_get_available_models_and_voices_object_voice_shape(self, mock_get):
+        """Test v0.4.0+ Kokoro-FastAPI shape: voices as [{"id","name"}, ...]."""
+        mock_models_response = Mock()
+        mock_models_response.raise_for_status.return_value = None
+        mock_models_response.json.return_value = {"data": [{"id": "kokoro"}]}
+
+        mock_voices_response = Mock()
+        mock_voices_response.raise_for_status.return_value = None
+        mock_voices_response.json.return_value = {
+            "voices": [
+                {"id": "af_bella", "name": "af_bella"},
+                {"id": "af_alloy", "name": "af_alloy"},
+            ]
+        }
+
+        def side_effect(url, **kwargs):
+            if "models" in url:
+                return mock_models_response
+            elif "voices" in url:
+                return mock_voices_response
+            raise ValueError(f"Unexpected URL: {url}")
+
+        mock_get.side_effect = side_effect
+
+        models, voices = convert.get_available_models_and_voices()
+
+        assert models == ["kokoro"]
+        assert voices == ["af_alloy", "af_bella"]
+
     @patch("time.sleep")
     @patch("requests.get")
     def test_get_available_models_and_voices_api_error(self, mock_get, mock_sleep):


### PR DESCRIPTION
Heads up: Kokoro-FastAPI v0.4.0 changed the `/v1/audio/voices` response shape.

Items in the `voices` array changed from plain strings to `{"id","name"}` objects (https://github.com/remsky/Kokoro-FastAPI/pull/462). Against the new shape, `sorted(voices_data)` in `audify/convert.py` raises `TypeError: '<' not supported between instances of 'dict' and 'dict'`.

This patch normalizes both shapes to a sorted list of ids, so audify keeps working against both old and new Kokoro-FastAPI servers without pinning.

(There's also a `?legacy=true` query param if you'd rather not change the client; but the normalization is one line so I figured a PR was easier.)

Tests: added `test_get_available_models_and_voices_object_voice_shape` covering the v0.4.0 shape; existing tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Kokoro voice data handling to support both current and legacy API response formats, ensuring seamless compatibility across different API versions.

* **Tests**
  * Added test coverage to validate proper handling and normalization of the newer Kokoro API response format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/garciadias/audify/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->