### PR TITLE
feat(qa): quality report aggregator + per-chapter flag schema

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,7 +148,7 @@ Each entry in `flags[chapter_id]` records:
 
 ### JSON shape
 
-```
+```json
 {
   "pipeline_status": "complete" | "partial" | "failed" | "no_chapters",
   "episodes_synthesised": int,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -115,3 +115,59 @@ without conditional edges.
 - **Graph state:** the shared object LangGraph carries between nodes and across
   back-edges — per-chapter retry budget, best-so-far WER, and the flags that
   feed the final quality report.
+
+## Quality report schema
+
+The terminal `report` node of every graph mode aggregates per-chapter
+**flags** raised by cyclic detectors into a single end-of-run report, written
+as `quality_report.json` (machine-readable) and `quality_report.txt`
+(human-readable Rich-rendered table) next to the M4B output.
+
+### Verdicts
+
+Per chapter, the aggregator emits one of three verdicts:
+
+- **`clean`** — no flag was raised against the chapter.
+- **`flagged`** — at least one cycle fired and resolved within its retry
+  budget (no `FlagEntry` has `exhausted=True`).
+- **`unrecoverable`** — at least one cycle ran out of retries
+  (`exhausted=True`). The best-effort artifact is kept on disk and the
+  chapter is surfaced in the report; the run does not abort. Mirrors the
+  warn-only halting philosophy of commit `0bffc34`.
+
+### `FlagEntry`
+
+Each entry in `flags[chapter_id]` records:
+
+- **`cycle`** — which remediation cycle fired the flag. Allowed values:
+  `cycle_1_escalation`, `cycle_2_reroute`, `cycle_3_retry`.
+- **`reason`** — short, human-readable diagnostic, e.g. `"WER 0.42 exceeds
+  0.3 threshold"` or `"text-extraction: mojibake"`.
+- **`exhausted`** — `True` when the cycle's retry budget reached zero;
+  `False` when the detector fired but the cycle resolved within budget.
+
+### JSON shape
+
+```
+{
+  "pipeline_status": "complete" | "partial" | "failed" | "no_chapters",
+  "episodes_synthesised": int,
+  "chapters_expected": int,
+  "verdict_counts": { "clean": int, "flagged": int, "unrecoverable": int },
+  "chapters": {
+    "chapter_<n>": {
+      "title": str,
+      "verdict": "clean" | "flagged" | "unrecoverable",
+      "attempts_used": { "<cycle_id>": int },
+      "best_wer": float | null,
+      "flags": [FlagEntry, ...]
+    }
+  }
+}
+```
+
+`attempts_used` only contains keys for cycles that actually fired against
+the chapter — cycles that never ran are omitted rather than reported as
+`0/3`. `best_wer` is populated only when `cycle_3_retry` ran; otherwise
+`null`. With stub data (no cyclic detector has shipped yet) every chapter
+is `clean` with an empty `flags` list.

--- a/audify/qa/nodes/report.py
+++ b/audify/qa/nodes/report.py
@@ -3,18 +3,60 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Optional
 
-from audify.qa.state import GraphState
+from rich.console import Console
+from rich.table import Table
+
+from audify.qa.state import FlagEntry, GraphState
 
 logger = logging.getLogger(__name__)
 
+# Per-cycle retry budget. Mirrors the bounded-attempts halting condition
+# documented in ADR-0001 ("Each back-edge must have a bounded halting
+# condition"). Each cycle owns its own counter.
+MAX_BUDGET_PER_CYCLE = 3
+
+# Canonical cycle ordering for table output. Matches the CycleId Literal in
+# audify.qa.state and the schema documented in CONTEXT.md.
+CYCLE_ORDER = ("cycle_1_escalation", "cycle_2_reroute", "cycle_3_retry")
+
+_VERDICT_STYLE = {
+    "clean": "green",
+    "flagged": "yellow",
+    "unrecoverable": "red",
+}
+
+_VERDICT_GLYPH = {
+    "clean": "✓",
+    "flagged": "⚠",
+    "unrecoverable": "✗",
+}
+
 
 def report_node(state: GraphState) -> dict:
-    """Write a JSON quality report alongside the output directory.
+    """Aggregate per-chapter flags into the end-of-run quality report.
 
-    Each chapter entry records the flags raised during the run, the number of
-    retry attempts consumed, and the best WER seen (populated by future
-    cycle nodes; empty in the linear skeleton).
+    Produces three artifacts:
+
+    * a Rich-rendered table printed to stdout,
+    * ``quality_report.txt`` next to the audiobook (same content as the
+      Rich table, plain text),
+    * ``quality_report.json`` next to the audiobook (machine-readable;
+      schema documented in ``CONTEXT.md``).
+
+    A chapter's verdict is derived from its ``FlagEntry`` list:
+
+    * ``clean`` — no flags raised.
+    * ``flagged`` — at least one flag, none exhausted (a cycle fired and
+      resolved within budget).
+    * ``unrecoverable`` — at least one flag with ``exhausted=True`` (a
+      cycle ran out of retries; best-effort artifact kept per ``0bffc34``).
+
+    When the creator was launched with ``--warn-stop`` and any chapter
+    ended up ``unrecoverable``, the aggregator prompts the user before
+    returning. The default (warn-only) path logs and continues without
+    prompting, preserving the behaviour established by commit ``0bffc34``.
     """
     creator = state["creator"]
     chapter_titles = state["chapter_titles"]
@@ -23,48 +65,191 @@ def report_node(state: GraphState) -> dict:
     best_wer = state.get("best_wer", {})
     retry_budget = state.get("retry_budget", {})
 
-    max_budget = 3
     chapters_report: dict[str, dict] = {}
     for i, title in enumerate(chapter_titles, 1):
         chapter_id = f"chapter_{i}"
-        budget_remaining = retry_budget.get(chapter_id, max_budget)
-        # Until the cyclic detectors land, no node writes to `flags` /
-        # `best_wer` / `retry_budget`. Surface that explicitly instead of
-        # reporting a misleading "ok" for every chapter.
-        chapter_flags = flags.get(chapter_id)
-        if chapter_flags:
-            verdict = "flagged"
-        elif chapter_id in best_wer or chapter_id in retry_budget:
-            verdict = "ok"
-        else:
-            verdict = "skeleton"
+        chapter_flags: list[FlagEntry] = flags.get(chapter_id, [])
+        chapter_budget = retry_budget.get(chapter_id, {})
+
+        verdict = _derive_verdict(chapter_flags)
+        attempts_used = _attempts_used(chapter_flags, chapter_budget)
+
         chapters_report[chapter_id] = {
             "title": title,
             "verdict": verdict,
-            "attempts_used": max_budget - budget_remaining,
+            "attempts_used": attempts_used,
             "best_wer": best_wer.get(chapter_id),
-            "flags": flags.get(chapter_id, []),
+            "flags": [dict(entry) for entry in chapter_flags],
         }
 
-    expected_chapters = len(chapter_titles)
-    if expected_chapters == 0:
-        pipeline_status = "no_chapters"
-    elif len(episode_paths) == expected_chapters:
-        pipeline_status = "complete"
-    elif len(episode_paths) == 0:
-        pipeline_status = "failed"
-    else:
-        pipeline_status = "partial"
+    pipeline_status = _derive_pipeline_status(chapter_titles, episode_paths)
+    verdict_counts = _count_verdicts(chapters_report)
 
     report = {
         "pipeline_status": pipeline_status,
         "episodes_synthesised": len(episode_paths),
-        "chapters_expected": expected_chapters,
+        "chapters_expected": len(chapter_titles),
+        "verdict_counts": verdict_counts,
         "chapters": chapters_report,
     }
 
-    report_path = Path(creator.audiobook_path) / "quality_report.json"
-    report_path.write_text(json.dumps(report, indent=2))
-    logger.info(f"Quality report written to {report_path}")
+    audiobook_path = Path(creator.audiobook_path)
+    audiobook_path.mkdir(parents=True, exist_ok=True)
+
+    json_path = audiobook_path / "quality_report.json"
+    json_path.write_text(json.dumps(report, indent=2))
+    logger.info(f"Quality report (JSON) written to {json_path}")
+
+    text_path = audiobook_path / "quality_report.txt"
+    rendered = _render_human_readable(
+        audiobook_path.name, chapters_report, verdict_counts, pipeline_status
+    )
+    text_path.write_text(rendered)
+    logger.info(f"Quality report (text) written to {text_path}")
+
+    # Preserve --warn-stop semantics from commit 0bffc34: unrecoverable
+    # verdicts surface as a prompt only when warn_stop is set; the default
+    # path warns and continues.
+    if verdict_counts.get("unrecoverable", 0) and getattr(
+        creator, "warn_stop", False
+    ):
+        _warn_stop_prompt(verdict_counts["unrecoverable"])
 
     return {}
+
+
+def _derive_verdict(chapter_flags: list[FlagEntry]) -> str:
+    if not chapter_flags:
+        return "clean"
+    if any(entry["exhausted"] for entry in chapter_flags):
+        return "unrecoverable"
+    return "flagged"
+
+
+def _attempts_used(
+    chapter_flags: list[FlagEntry],
+    chapter_budget: dict[str, int],
+) -> dict[str, int]:
+    """Return attempts-used per cycle, only for cycles that actually fired.
+
+    A cycle is considered "fired" if it has either a remaining-budget entry
+    or a flag entry. Cycles that never ran are omitted from the dict rather
+    than reported as ``0/3`` — keeps the report focused on what actually
+    happened.
+    """
+    fired_cycles = set(chapter_budget.keys()) | {
+        entry["cycle"] for entry in chapter_flags
+    }
+    return {
+        cycle: MAX_BUDGET_PER_CYCLE - chapter_budget.get(cycle, MAX_BUDGET_PER_CYCLE)
+        for cycle in fired_cycles
+    }
+
+
+def _derive_pipeline_status(
+    chapter_titles: list[str],
+    episode_paths: list,
+) -> str:
+    expected = len(chapter_titles)
+    produced = len(episode_paths)
+    if expected == 0:
+        return "no_chapters"
+    if produced == expected:
+        return "complete"
+    if produced == 0:
+        return "failed"
+    return "partial"
+
+
+def _count_verdicts(chapters_report: dict[str, dict]) -> dict[str, int]:
+    counts = {"clean": 0, "flagged": 0, "unrecoverable": 0}
+    for entry in chapters_report.values():
+        counts[entry["verdict"]] += 1
+    return counts
+
+
+def _render_human_readable(
+    audiobook_name: str,
+    chapters_report: dict[str, dict],
+    verdict_counts: dict[str, int],
+    pipeline_status: str,
+) -> str:
+    """Render the report to stdout and return the captured plain-text form."""
+    console = Console(record=True)
+
+    table = Table(title=f"Quality Report — {audiobook_name}")
+    table.add_column("Chapter", overflow="fold")
+    table.add_column("Verdict")
+    table.add_column("Details", overflow="fold")
+
+    for chapter_id, entry in chapters_report.items():
+        verdict = entry["verdict"]
+        glyph = _VERDICT_GLYPH.get(verdict, " ")
+        style = _VERDICT_STYLE.get(verdict, "")
+        table.add_row(
+            f"{chapter_id} — {entry['title']}",
+            f"{glyph} {verdict}",
+            _format_details(entry),
+            style=style,
+        )
+
+    console.print(table)
+    summary = (
+        f"Summary: {verdict_counts['clean']} clean · "
+        f"{verdict_counts['flagged']} flagged · "
+        f"{verdict_counts['unrecoverable']} unrecoverable · "
+        f"{len(chapters_report)} expected · "
+        f"pipeline_status={pipeline_status}"
+    )
+    console.print(summary)
+    return console.export_text()
+
+
+def _format_details(entry: dict) -> str:
+    flags: list[dict] = entry["flags"]
+    if not flags:
+        return ""
+
+    best_wer: Optional[float] = entry.get("best_wer")
+    attempts: dict[str, int] = entry["attempts_used"]
+    parts: list[str] = []
+    for flag in flags:
+        cycle = flag["cycle"]
+        used = attempts.get(cycle, 0)
+        if flag["exhausted"]:
+            tail = f"{used}/{MAX_BUDGET_PER_CYCLE} attempts exhausted"
+        else:
+            tail = "resolved"
+        suffix = f" — {flag['reason']}" if flag.get("reason") else ""
+        if cycle == "cycle_3_retry" and best_wer is not None:
+            tail = f"{tail}, best WER {best_wer:.2f}"
+        parts.append(f"{cycle} ({tail}){suffix}")
+    return "; ".join(parts)
+
+
+def _warn_stop_prompt(unrecoverable_count: int) -> None:
+    """Prompt the user when warn-stop is set and unrecoverable flags exist.
+
+    No-ops the prompt on EOFError / OSError (non-tty environments such as
+    CI captures), so the warn-stop guard never hangs the run.
+    """
+    message = (
+        f"\n⚠️  Quality report flagged {unrecoverable_count} chapter"
+        f"{'s' if unrecoverable_count != 1 else ''} as unrecoverable. "
+        "Accept anyway? (y/N): "
+    )
+    try:
+        response = input(message)
+    except (EOFError, OSError):
+        logger.warning(
+            "warn-stop set but no interactive stdin available; "
+            "continuing without prompt."
+        )
+        return
+    if response.lower() in ("y", "yes"):
+        logger.info("User accepted audiobook despite unrecoverable chapters.")
+    else:
+        logger.warning(
+            "User did not accept audiobook; "
+            "best-effort artifact kept on disk, review flagged chapters."
+        )

--- a/audify/qa/nodes/report.py
+++ b/audify/qa/nodes/report.py
@@ -8,7 +8,7 @@ from typing import Optional
 from rich.console import Console
 from rich.table import Table
 
-from audify.qa.state import FlagEntry, GraphState
+from audify.qa.state import CycleId, FlagEntry, GraphState
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +128,7 @@ def _derive_verdict(chapter_flags: list[FlagEntry]) -> str:
 
 def _attempts_used(
     chapter_flags: list[FlagEntry],
-    chapter_budget: dict[str, int],
+    chapter_budget: dict[CycleId, int],
 ) -> dict[str, int]:
     """Return attempts-used per cycle, only for cycles that actually fired.
 
@@ -136,13 +136,20 @@ def _attempts_used(
     or a flag entry. Cycles that never ran are omitted from the dict rather
     than reported as ``0/3`` — keeps the report focused on what actually
     happened.
+
+    Iterates over :data:`CYCLE_ORDER` (then any unknown cycles in sorted
+    order) so the resulting dict has deterministic key insertion order,
+    keeping ``quality_report.json`` diffs stable across runs.
     """
     fired_cycles = set(chapter_budget.keys()) | {
         entry["cycle"] for entry in chapter_flags
     }
+    ordered_cycles = [c for c in CYCLE_ORDER if c in fired_cycles] + sorted(
+        fired_cycles - set(CYCLE_ORDER)
+    )
     return {
         cycle: MAX_BUDGET_PER_CYCLE - chapter_budget.get(cycle, MAX_BUDGET_PER_CYCLE)
-        for cycle in fired_cycles
+        for cycle in ordered_cycles
     }
 
 

--- a/audify/qa/state.py
+++ b/audify/qa/state.py
@@ -76,7 +76,7 @@ class GraphState(TypedDict):
     chapter_scripts: list[tuple[int, str]]
     episode_paths: list[Path]
     # retry_budget[chapter_id][cycle_id] = remaining attempts for that cycle
-    retry_budget: dict[str, dict[str, int]]
+    retry_budget: dict[str, dict[CycleId, int]]
     # best_wer[chapter_id] = lowest WER seen across cycle-3 retry attempts
     best_wer: dict[str, float]
     # flags[chapter_id] = ordered list of FlagEntry raised against the chapter

--- a/audify/qa/state.py
+++ b/audify/qa/state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from typing_extensions import TypeAlias, TypedDict
+from typing_extensions import Literal, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
     # Only imported for type-checkers; the runtime field is kept as ``Any``
@@ -19,6 +19,37 @@ else:
     CreatorT = Any
 
 
+CycleId = Literal[
+    "cycle_1_escalation",
+    "cycle_2_reroute",
+    "cycle_3_retry",
+]
+"""Canonical identifiers for the three remediation cycles (see ADR-0001)."""
+
+
+class FlagEntry(TypedDict):
+    """One quality-check flag raised against a chapter during the run.
+
+    Cyclic detectors (#3 retry, #4 reroute, #5 escalation) append a
+    ``FlagEntry`` to ``GraphState.flags[chapter_id]`` each time a Quality
+    Check fires. The aggregator consumes the list to derive a per-chapter
+    verdict and surface diagnostics in the final quality report.
+
+    Fields:
+        cycle: which remediation cycle raised the flag.
+        reason: short, human-readable diagnostic, e.g.
+            ``"text-extraction: mojibake"`` or
+            ``"WER 0.42 exceeds 0.3 threshold"``.
+        exhausted: ``True`` when the cycle's retry budget reached zero and
+            the best-effort artifact was kept. ``False`` when the detector
+            fired but the cycle resolved within its budget.
+    """
+
+    cycle: CycleId
+    reason: str
+    exhausted: bool
+
+
 class GraphState(TypedDict):
     """Shared state carried by the LangGraph QA pipeline between nodes.
 
@@ -26,6 +57,12 @@ class GraphState(TypedDict):
     keyed by ``chapter_id`` (``"chapter_{episode_number}"``).  They are
     populated as the graph processes each chapter and are consumed by the
     report node at the end.
+
+    ``retry_budget`` is two-level: outer key is the chapter id, inner key is
+    the cycle id from :data:`CycleId`. Each cycle owns an independent
+    counter so the aggregator can report attempts-used per cycle. Empty
+    dictionaries are valid at every level — the cyclic detectors populate
+    their own slots lazily as they fire.
     """
 
     # ``CreatorT`` is ``Any`` at runtime (LangGraph evaluates this) and
@@ -38,9 +75,9 @@ class GraphState(TypedDict):
     # list of (episode_number, script) pairs produced by script_gen
     chapter_scripts: list[tuple[int, str]]
     episode_paths: list[Path]
-    # retry_budget[chapter_id] = remaining attempts (starts at 3 per cycle)
-    retry_budget: dict[str, int]
-    # best_wer[chapter_id] = lowest WER seen across retry attempts
+    # retry_budget[chapter_id][cycle_id] = remaining attempts for that cycle
+    retry_budget: dict[str, dict[str, int]]
+    # best_wer[chapter_id] = lowest WER seen across cycle-3 retry attempts
     best_wer: dict[str, float]
-    # flags[chapter_id] = human-readable flag strings for the quality report
-    flags: dict[str, list[str]]
+    # flags[chapter_id] = ordered list of FlagEntry raised against the chapter
+    flags: dict[str, list[FlagEntry]]

--- a/tests/test_qa_graph.py
+++ b/tests/test_qa_graph.py
@@ -33,6 +33,10 @@ def _make_creator(tmp_path: Path, chapters: list[str] | None = None) -> MagicMoc
     # Default to non-interactive (matches `-y/--confirm` flag): skip the
     # confirm_node prompt so the test doesn't hang on stdin.
     creator.confirm = False
+    # Default `warn_stop` to False so the report node's warn-stop prompt
+    # never fires in tests that don't set it explicitly. A MagicMock would
+    # otherwise read as truthy here.
+    creator.warn_stop = False
 
     # reader is a non-EpubReader so we get the simple path. Using
     # ``MagicMock(spec=PdfReader)`` gives a durable ``isinstance`` answer
@@ -131,9 +135,10 @@ class TestRunGraph:
         assert report["episodes_synthesised"] == report["chapters_expected"]
         chapters = report["chapters"]
         assert "chapter_1" in chapters
-        # Until the cyclic detectors run, "skeleton" is the honest verdict —
-        # no cycle node has yet populated ``best_wer``/``retry_budget``.
-        assert chapters["chapter_1"]["verdict"] == "skeleton"
+        # No cycle has fired against the stub-data path, so every chapter
+        # is ``clean``. The detectors (#3/#4/#5) will populate ``flags`` as
+        # they ship; the aggregator already speaks their schema.
+        assert chapters["chapter_1"]["verdict"] == "clean"
         assert chapters["chapter_1"]["flags"] == []
 
     def test_run_graph_returns_audiobook_path(self, tmp_path):
@@ -431,3 +436,351 @@ class TestSynthesizeNode:
         }
         result = synthesize_node(state)
         assert result["episode_paths"] == []
+
+
+class TestReportNode:
+    """Verdict derivation and artifact generation for the report aggregator.
+
+    Covers issue #37's required flag types: clean, cycle-1 escalation
+    exhausted, cycle-2 reroute exhausted, cycle-3 retry exhausted. Uses
+    ``report_node`` directly with a synthesised state so each verdict path
+    is exercised in isolation — independent of the upstream detectors,
+    which have not shipped yet.
+    """
+
+    def _stub_creator(self, tmp_path: Path, warn_stop: bool = False) -> MagicMock:
+        creator = MagicMock()
+        creator.audiobook_path = tmp_path
+        creator.warn_stop = warn_stop
+        return creator
+
+    def _state(
+        self,
+        creator: MagicMock,
+        *,
+        chapter_titles: list[str],
+        flags: dict | None = None,
+        retry_budget: dict | None = None,
+        best_wer: dict | None = None,
+        episode_paths: list | None = None,
+    ) -> dict:
+        return {
+            "creator": creator,
+            "chapters": [],
+            "chapter_titles": chapter_titles,
+            "chapter_scripts": [],
+            # Default: one dummy episode path per chapter, so the default
+            # ``pipeline_status`` is ``"complete"`` and tests focus on
+            # verdict logic. Tests can override by passing ``episode_paths``.
+            "episode_paths": (
+                episode_paths
+                if episode_paths is not None
+                else [Path(f"ep_{i}.mp3") for i in range(len(chapter_titles))]
+            ),
+            "retry_budget": retry_budget or {},
+            "best_wer": best_wer or {},
+            "flags": flags or {},
+        }
+
+    def _load_report(self, tmp_path: Path) -> dict:
+        return json.loads((tmp_path / "quality_report.json").read_text())
+
+    def test_clean_when_no_flags(self, tmp_path):
+        """No flags → every chapter is `clean`."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(creator, chapter_titles=["Ch 1", "Ch 2"])
+        report_node(state)
+
+        report = self._load_report(tmp_path)
+        assert report["chapters"]["chapter_1"]["verdict"] == "clean"
+        assert report["chapters"]["chapter_2"]["verdict"] == "clean"
+        assert report["chapters"]["chapter_1"]["flags"] == []
+        assert report["verdict_counts"] == {
+            "clean": 2, "flagged": 0, "unrecoverable": 0,
+        }
+
+    def test_flagged_when_cycle_resolved(self, tmp_path):
+        """A FlagEntry with `exhausted=False` yields `flagged`, not unrecoverable."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_3_retry",
+                        "reason": "WER 0.32 exceeded threshold once",
+                        "exhausted": False,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_3_retry": 2}},
+            best_wer={"chapter_1": 0.18},
+        )
+        report_node(state)
+
+        report = self._load_report(tmp_path)
+        assert report["chapters"]["chapter_1"]["verdict"] == "flagged"
+        assert report["chapters"]["chapter_1"]["attempts_used"] == {
+            "cycle_3_retry": 1,
+        }
+        assert report["chapters"]["chapter_1"]["best_wer"] == 0.18
+        assert report["verdict_counts"]["flagged"] == 1
+
+    def test_unrecoverable_cycle_3_retry_exhausted(self, tmp_path):
+        """Cycle-3 retry exhaustion: unrecoverable, 3/3 attempts, best WER surfaced."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_3_retry",
+                        "reason": "WER 0.42 exceeds 0.3 threshold",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_3_retry": 0}},
+            best_wer={"chapter_1": 0.42},
+        )
+        report_node(state)
+
+        report = self._load_report(tmp_path)
+        entry = report["chapters"]["chapter_1"]
+        assert entry["verdict"] == "unrecoverable"
+        assert entry["attempts_used"] == {"cycle_3_retry": 3}
+        assert entry["best_wer"] == 0.42
+        assert entry["flags"][0]["exhausted"] is True
+        assert report["verdict_counts"]["unrecoverable"] == 1
+
+    def test_unrecoverable_cycle_2_reroute_exhausted(self, tmp_path):
+        """Cycle-2 reroute exhaustion: verdict `unrecoverable`, no best_wer."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_2_reroute",
+                        "reason": "LLM produced a summary, not a narration",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_2_reroute": 0}},
+        )
+        report_node(state)
+
+        report = self._load_report(tmp_path)
+        entry = report["chapters"]["chapter_1"]
+        assert entry["verdict"] == "unrecoverable"
+        assert entry["attempts_used"] == {"cycle_2_reroute": 3}
+        assert entry["best_wer"] is None
+
+    def test_unrecoverable_cycle_1_escalation_exhausted(self, tmp_path):
+        """Cycle-1 escalation exhaustion: verdict `unrecoverable`."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_1_escalation",
+                        "reason": "text-extraction: mojibake after OCR fallback",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_1_escalation": 0}},
+        )
+        report_node(state)
+
+        report = self._load_report(tmp_path)
+        entry = report["chapters"]["chapter_1"]
+        assert entry["verdict"] == "unrecoverable"
+        assert entry["attempts_used"] == {"cycle_1_escalation": 3}
+
+    def test_human_readable_report_written(self, tmp_path):
+        """`quality_report.txt` is written alongside the JSON report."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(creator, chapter_titles=["Ch 1"])
+        report_node(state)
+
+        text_path = tmp_path / "quality_report.txt"
+        assert text_path.exists(), "Human-readable report must be written"
+        content = text_path.read_text()
+        # Rich table header + the verdict glyph for ``clean`` must be present.
+        assert "Quality Report" in content
+        assert "clean" in content
+        assert "Summary:" in content
+
+    def test_warn_stop_prompts_on_unrecoverable(self, tmp_path, monkeypatch):
+        """`warn_stop=True` with an unrecoverable verdict invokes the input prompt."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path, warn_stop=True)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_3_retry",
+                        "reason": "boundary STT mismatch",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_3_retry": 0}},
+        )
+
+        prompts: list[str] = []
+
+        def _fake_input(prompt: str) -> str:
+            prompts.append(prompt)
+            return "y"
+
+        monkeypatch.setattr("builtins.input", _fake_input)
+        report_node(state)
+        assert len(prompts) == 1
+        assert "unrecoverable" in prompts[0]
+
+    def test_warn_stop_user_rejects(self, tmp_path, monkeypatch, caplog):
+        """Rejecting at the prompt logs a warning; the run still completes."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path, warn_stop=True)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_3_retry",
+                        "reason": "boundary STT mismatch",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_3_retry": 0}},
+        )
+
+        monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+        with caplog.at_level("WARNING", logger="audify.qa.nodes.report"):
+            report_node(state)
+        # JSON is still written even when the user rejects.
+        assert (tmp_path / "quality_report.json").exists()
+        assert any(
+            "User did not accept audiobook" in r.message for r in caplog.records
+        )
+
+    def test_warn_stop_off_does_not_prompt(self, tmp_path, monkeypatch):
+        """`warn_stop=False` (default) never prompts, even with unrecoverables."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path, warn_stop=False)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_3_retry",
+                        "reason": "boundary STT mismatch",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_3_retry": 0}},
+        )
+
+        def _should_not_be_called(prompt: str) -> str:
+            raise AssertionError(f"input() called unexpectedly with: {prompt!r}")
+
+        monkeypatch.setattr("builtins.input", _should_not_be_called)
+        report_node(state)  # Must not raise
+
+    def test_warn_stop_skipped_when_only_flagged(self, tmp_path, monkeypatch):
+        """`warn_stop` only triggers on unrecoverable, not on soft flags."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path, warn_stop=True)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_3_retry",
+                        "reason": "single retry resolved",
+                        "exhausted": False,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_3_retry": 2}},
+        )
+
+        def _should_not_be_called(prompt: str) -> str:
+            raise AssertionError(f"input() called unexpectedly with: {prompt!r}")
+
+        monkeypatch.setattr("builtins.input", _should_not_be_called)
+        report_node(state)
+
+    def test_warn_stop_non_tty_does_not_hang(self, tmp_path, monkeypatch):
+        """EOFError on stdin (CI/non-tty) is swallowed; the run completes."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path, warn_stop=True)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1"],
+            flags={
+                "chapter_1": [
+                    {
+                        "cycle": "cycle_1_escalation",
+                        "reason": "mojibake",
+                        "exhausted": True,
+                    },
+                ],
+            },
+            retry_budget={"chapter_1": {"cycle_1_escalation": 0}},
+        )
+
+        def _no_stdin(_prompt: str) -> str:
+            raise EOFError("no stdin")
+
+        monkeypatch.setattr("builtins.input", _no_stdin)
+        report_node(state)  # Must not raise
+
+    def test_pipeline_status_partial_when_some_episodes_missing(self, tmp_path):
+        """`pipeline_status=partial` when episodes < expected and > 0."""
+        from audify.qa.nodes.report import report_node
+
+        creator = self._stub_creator(tmp_path)
+        state = self._state(
+            creator,
+            chapter_titles=["Ch 1", "Ch 2"],
+            episode_paths=[tmp_path / "ep_1.mp3"],
+        )
+        report_node(state)
+
+        report = self._load_report(tmp_path)
+        assert report["pipeline_status"] == "partial"
+        assert report["episodes_synthesised"] == 1
+        assert report["chapters_expected"] == 2

--- a/tests/test_qa_graph.py
+++ b/tests/test_qa_graph.py
@@ -742,8 +742,15 @@ class TestReportNode:
         monkeypatch.setattr("builtins.input", _should_not_be_called)
         report_node(state)
 
-    def test_warn_stop_non_tty_does_not_hang(self, tmp_path, monkeypatch):
-        """EOFError on stdin (CI/non-tty) is swallowed; the run completes."""
+    @pytest.mark.parametrize(
+        "stdin_exc",
+        [EOFError("no stdin"), OSError("no stdin")],
+        ids=["eof", "oserror"],
+    )
+    def test_warn_stop_non_tty_does_not_hang(
+        self, tmp_path, monkeypatch, stdin_exc
+    ):
+        """EOFError/OSError on stdin (CI/non-tty) is swallowed; run completes."""
         from audify.qa.nodes.report import report_node
 
         creator = self._stub_creator(tmp_path, warn_stop=True)
@@ -763,7 +770,7 @@ class TestReportNode:
         )
 
         def _no_stdin(_prompt: str) -> str:
-            raise EOFError("no stdin")
+            raise stdin_exc
 
         monkeypatch.setattr("builtins.input", _no_stdin)
         report_node(state)  # Must not raise


### PR DESCRIPTION
## Summary

Closes #37. Hardens the skeleton `report_node` into the terminal aggregator that every back-edge cycle in the agentic QA loop converges on. The report node now speaks the verdict taxonomy and per-cycle attempt schema the issue called out, so cycles #38/#39/#40 can ship one at a time without touching the aggregator again.

- `GraphState.retry_budget` is now two-level (`chapter -> cycle -> remaining`) and `GraphState.flags` is now `dict[str, list[FlagEntry]]`. `FlagEntry` and `CycleId` are typed in `audify/qa/state.py` so detectors can append flags without the aggregator caring which one ran.
- Aggregator emits both a Rich-rendered `quality_report.txt` (printed to stdout and persisted next to the M4B) and the machine-readable `quality_report.json` whose schema is now documented in `CONTEXT.md`.
- `--warn-stop` semantics from commit `0bffc34` are preserved end-to-end: the prompt fires only when `unrecoverable` chapters exist *and* the creator opted in. Non-tty environments (CI) get an EOF-swallowing fallback so the run never hangs.

## Verdict taxonomy

| Verdict | Trigger |
|---|---|
| `clean` | No flag raised against the chapter. |
| `flagged` | At least one cycle fired and resolved within its retry budget (no `FlagEntry.exhausted == True`). |
| `unrecoverable` | At least one cycle ran out of retries (best-effort artifact kept on disk; run does not abort). |

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan

- [x] `uv run ruff check ./audify ./tests` — clean.
- [x] `uv run pytest tests/test_qa_graph.py` — 44 passed (11 new in `TestReportNode`).
- [x] `TestReportNode` covers each flag type called out in the issue: `clean`, cycle-1 escalation exhausted, cycle-2 reroute exhausted, cycle-3 retry exhausted, plus the soft-flagged path, the human-readable output artifact, the warn-stop prompt accept / reject / non-tty / off / flagged-only branches, and `pipeline_status=partial`.
- [x] End-to-end `TestRunGraph.test_run_graph_writes_quality_report` still passes against the stub-data path — every chapter is `clean` until detectors ship.

## Related

Closes #37. Unblocks #38 / #39 / #40 (the three cyclic detectors) — each can land independently and start appending `FlagEntry` objects to `state["flags"]` without revisiting the aggregator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quality reports now include chapter verdicts (clean, flagged, unrecoverable) with detailed per-cycle information
  * Human-readable quality report format with summary tables and flag details
  * Optional interactive prompting when critical quality issues are detected

* **Documentation**
  * Quality report schema specification added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->