### PR TITLE
feat(qa): cycle-3 fidelity check with re-chunk retry edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,23 @@ task audiobook "book.epub" --synthesize-only
 
 If a run is interrupted, re-running the same command will automatically skip episodes whose MP3 files already exist.
 
+### Agentic QA Pipeline (experimental)
+
+The `--graph` flag runs the LangGraph-based agentic pipeline instead of the legacy
+orchestrator. It adds quality-assurance cycles on top of the same
+`read → script_gen → synthesize → assemble → report` stages (see `docs/graph.md`).
+
+```bash
+# Run the graph pipeline with the boundary-sampling fidelity check enabled
+task audiobook "book.epub" --graph --fidelity-check
+```
+
+`--fidelity-check` enables the cycle-3 detector: after each episode is synthesized
+it transcribes the head and tail of the audio via the STT service and re-chunks /
+re-synthesizes any chapter that looks truncated (up to 3 attempts), recording the
+outcome in `quality_report.json`. It requires the docker-compose STT service
+(`faster-whisper` on port 8888) and self-disables if no service is reachable.
+
 ### Advanced Options
 
 ```bash

--- a/audify/audiobook_creator.py
+++ b/audify/audiobook_creator.py
@@ -275,6 +275,7 @@ class AudiobookCreator(BaseSynthesizer):
         prompt_file: Optional[str | Path] = None,
         mode: str = "full",
         warn_stop: bool = False,
+        fidelity_check: bool = False,
     ):
         self.reader: Union[EpubReader, PdfReader]
         file_path = Path(path)
@@ -321,6 +322,11 @@ class AudiobookCreator(BaseSynthesizer):
         self.max_chapters = max_chapters
         self.confirm = confirm
         self.warn_stop = warn_stop
+        # Cycle-3 boundary-sampling fidelity check (issue #38). Opt-in: requires
+        # the docker-compose STT service. ``stt_client`` may be injected for
+        # tests; when None the fidelity node builds a WhisperSTTClient from env.
+        self.fidelity_check = fidelity_check
+        self.stt_client: Optional[object] = None
         self.progress = ProgressIndicator()
 
         # Resolve task prompt and LLM parameters
@@ -611,8 +617,18 @@ class AudiobookCreator(BaseSynthesizer):
 
         return audiobook_script
 
-    def synthesize_episode(self, audiobook_script: str, episode_number: int) -> Path:
-        """Synthesizes a single audiobook episode from script."""
+    def synthesize_episode(
+        self,
+        audiobook_script: str,
+        episode_number: int,
+        max_text_length: Optional[int] = None,
+    ) -> Path:
+        """Synthesizes a single audiobook episode from script.
+
+        *max_text_length* overrides the TTS batch size for this episode (used by
+        the cycle-3 retry edge to re-chunk smaller); ``None`` uses the provider
+        default.
+        """
         logger.info(f"Synthesizing Audiobook Episode {episode_number}...")
         # Use standardized episode file naming (tests expect episode_###.wav)
         episode_wav_path = self.episodes_path / f"episode_{episode_number:03d}.wav"
@@ -660,7 +676,9 @@ class AudiobookCreator(BaseSynthesizer):
             return episode_mp3_path
 
         try:
-            self._synthesize_sentences(sentences, episode_wav_path)
+            self._synthesize_sentences(
+                sentences, episode_wav_path, max_text_length=max_text_length
+            )
             return self._convert_to_mp3(episode_wav_path)
         except Exception as e:
             logger.error(

--- a/audify/cli.py
+++ b/audify/cli.py
@@ -615,6 +615,13 @@ def cli(
     else:
         mode = "full"
 
+    if fidelity_check and not graph:
+        click.echo(
+            "Error: --fidelity-check requires --graph.",
+            err=True,
+        )
+        ctx.exit(1)
+
     path_obj = Path(path_str)
 
     if not path_obj.exists():

--- a/audify/cli.py
+++ b/audify/cli.py
@@ -399,6 +399,17 @@ def _contains_audio_artifacts(output_path: Path) -> bool:
     ),
 )
 @click.option(
+    "--fidelity-check",
+    is_flag=True,
+    default=False,
+    help=(
+        "Enable the cycle-3 boundary-sampling fidelity check (requires --graph "
+        "and the docker-compose STT service). Transcribes the head/tail of each "
+        "episode and re-chunks/re-synthesizes chapters that look truncated, up "
+        "to 3 attempts. Self-disables when no STT service is reachable."
+    ),
+)
+@click.option(
     "--verbose",
     is_flag=True,
     help="Show detailed log messages in terminal.",
@@ -438,6 +449,7 @@ def cli(
     process_only: bool,
     synthesize_only: bool,
     graph: bool,
+    fidelity_check: bool,
     verbose: bool,
     warn_stop: bool,
     path: str | None,
@@ -759,6 +771,7 @@ def cli(
                 prompt_file=prompt_file,
                 mode=mode,
                 warn_stop=warn_stop,
+                fidelity_check=fidelity_check,
             )
             if graph:
                 from audify.qa.graph import run_graph

--- a/audify/convert.py
+++ b/audify/convert.py
@@ -55,6 +55,7 @@ def get_creator(
     prompt_file: str | None = None,
     mode: str = "full",
     warn_stop: bool = False,
+    fidelity_check: bool = False,
 ) -> AudiobookCreator:
     """Get the appropriate AudiobookCreator subclass based on file extension.
 
@@ -87,6 +88,7 @@ def get_creator(
             prompt_file=prompt_file,
             mode=mode,
             warn_stop=warn_stop,
+            fidelity_check=fidelity_check,
         )
     elif file_extension == ".pdf":
         # remove max_chapters for PDF
@@ -106,6 +108,7 @@ def get_creator(
             prompt_file=prompt_file,
             mode=mode,
             warn_stop=warn_stop,
+            fidelity_check=fidelity_check,
         )
     else:
         raise TypeError(f"Unsupported file format '{file_extension}'")

--- a/audify/qa/graph.py
+++ b/audify/qa/graph.py
@@ -7,12 +7,18 @@ from langgraph.graph import END, StateGraph
 
 from audify.qa.nodes.assemble import assemble_node
 from audify.qa.nodes.confirm import confirm_node
+from audify.qa.nodes.fidelity import fidelity_node, fidelity_route
 from audify.qa.nodes.load_scripts import load_scripts_node
 from audify.qa.nodes.read import read_node
 from audify.qa.nodes.report import report_node
 from audify.qa.nodes.script_gen import script_gen_node
 from audify.qa.nodes.synthesize import synthesize_node
 from audify.qa.state import GraphState
+
+# Bound on graph supersteps. The cycle-3 retry edge loops
+# synthesize ↔ fidelity at most MAX_BUDGET_PER_CYCLE times per run, so the
+# default LangGraph limit (25) is ample; set explicitly for clarity/safety.
+_RECURSION_LIMIT = 50
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
@@ -23,12 +29,15 @@ if TYPE_CHECKING:
 def build_graph(mode: str = "full") -> "CompiledStateGraph":
     """Assemble the QA pipeline graph for the requested *mode*.
 
-    Three topologies, each acyclic (no back-edges in this skeleton):
+    Three topologies:
 
-    * ``"full"`` — ``read → script_gen → synthesize → assemble → report → END``
-    * ``"process"`` — ``read → script_gen → report → END`` (no TTS)
-    * ``"synthesize"`` — ``load_scripts → synthesize → assemble → report → END``
-      (loads previously-saved scripts, no LLM)
+    * ``"full"`` — ``read → confirm → script_gen → synthesize → fidelity →
+      assemble → report → END`` with a cycle-3 ``fidelity → synthesize``
+      retry back-edge.
+    * ``"process"`` — ``read → confirm → script_gen → report → END`` (no TTS,
+      acyclic).
+    * ``"synthesize"`` — ``load_scripts → synthesize → fidelity → assemble →
+      report → END`` (loads previously-saved scripts, no LLM; retry edge applies).
 
     Each shape mirrors the corresponding branch of the legacy
     ``AudiobookCreator.create_audiobook_series`` orchestrator.
@@ -51,6 +60,7 @@ def _build_full_graph() -> "CompiledStateGraph":
     builder.add_node("confirm", confirm_node)
     builder.add_node("script_gen", script_gen_node)
     builder.add_node("synthesize", synthesize_node)
+    builder.add_node("fidelity", fidelity_node)
     builder.add_node("assemble", assemble_node)
     builder.add_node("report", report_node)
 
@@ -58,7 +68,14 @@ def _build_full_graph() -> "CompiledStateGraph":
     builder.add_edge("read", "confirm")
     builder.add_edge("confirm", "script_gen")
     builder.add_edge("script_gen", "synthesize")
-    builder.add_edge("synthesize", "assemble")
+    builder.add_edge("synthesize", "fidelity")
+    # Cycle-3 retry edge: loop back to synthesize while episodes are flagged
+    # for re-chunk, otherwise continue to assemble.
+    builder.add_conditional_edges(
+        "fidelity",
+        fidelity_route,
+        {"synthesize": "synthesize", "assemble": "assemble"},
+    )
     builder.add_edge("assemble", "report")
     builder.add_edge("report", END)
     return builder.compile()
@@ -83,12 +100,18 @@ def _build_synthesize_graph() -> "CompiledStateGraph":
     builder: StateGraph = StateGraph(GraphState)
     builder.add_node("load_scripts", load_scripts_node)
     builder.add_node("synthesize", synthesize_node)
+    builder.add_node("fidelity", fidelity_node)
     builder.add_node("assemble", assemble_node)
     builder.add_node("report", report_node)
 
     builder.set_entry_point("load_scripts")
     builder.add_edge("load_scripts", "synthesize")
-    builder.add_edge("synthesize", "assemble")
+    builder.add_edge("synthesize", "fidelity")
+    builder.add_conditional_edges(
+        "fidelity",
+        fidelity_route,
+        {"synthesize": "synthesize", "assemble": "assemble"},
+    )
     builder.add_edge("assemble", "report")
     builder.add_edge("report", END)
     return builder.compile()
@@ -123,9 +146,11 @@ def run_graph(creator: "AudiobookCreator") -> Path:
         "retry_budget": {},
         "best_wer": {},
         "flags": {},
+        "pending_retry": [],
+        "episodes_to_check": [],
     }
 
-    graph.invoke(initial_state)
+    graph.invoke(initial_state, {"recursion_limit": _RECURSION_LIMIT})
     return Path(creator.audiobook_path)
 
 
@@ -143,14 +168,24 @@ def render_mermaid(output_path: Path = Path("docs/graph.md")) -> None:
     output_path.write_text(
         "# QA Pipeline Graph\n\n"
         "Topology of the LangGraph QA pipeline in `full` mode "
-        "(`read → script_gen → synthesize → assemble → report`).\n\n"
+        "(`read → confirm → script_gen → synthesize → fidelity → "
+        "assemble → report`).\n\n"
         f"```mermaid\n{diagram}\n```\n\n"
+        "## Cycle 3 — fidelity retry edge\n\n"
+        "`fidelity` boundary-samples each freshly-synthesized episode "
+        "(head/tail STT round-trip + duration ratio). When it suspects TTS "
+        "truncation it loops back to `synthesize` to re-chunk the offending "
+        "episode on a smaller batch size, bounded to 3 retries per chapter "
+        "(the `fidelity → synthesize` back-edge above). On exhaustion the "
+        "lowest-WER attempt is kept and the chapter is flagged in the report; "
+        "the run never aborts.\n\n"
         "## Sub-graphs\n\n"
         "* **`process` mode** (`--process-only`): "
         "`read → confirm → script_gen → report → END` — no TTS, no M4B.\n"
         "* **`synthesize` mode** (`--synthesize-only`): "
-        "`load_scripts → synthesize → assemble → report → END` — "
-        "scripts are loaded from a previous `--process-only` run.\n"
+        "`load_scripts → synthesize → fidelity → assemble → report → END` — "
+        "scripts are loaded from a previous `--process-only` run; the cycle-3 "
+        "retry edge applies here too.\n"
     )
     print(f"Graph diagram written to {output_path}")
 

--- a/audify/qa/nodes/fidelity.py
+++ b/audify/qa/nodes/fidelity.py
@@ -1,0 +1,315 @@
+"""Cycle-3 fidelity detector node — boundary-sampling + re-chunk retry edge.
+
+After ``synthesize`` produces episode audio, this node transcribes a short head
+window and a short tail window of each freshly-synthesized episode through the STT
+client (issue #36) and fuzzy-matches each transcript against the opening / closing
+words of the *script* that was fed to TTS. A high WER on either window — or a
+duration ratio that corroborates a shorter-than-expected episode — flags the chapter
+as a suspected TTS truncation (``CONTEXT.md`` → *Fidelity check*, *Boundary-sampling*).
+
+Flagged chapters with remaining budget are scheduled for re-synthesis on a smaller
+batch size (the only permitted remediation — *Retry edge*). The loop is bounded to
+``MAX_BUDGET_PER_CYCLE`` retries per chapter; on exhaustion the lowest-WER attempt is
+kept on disk and an ``exhausted=True`` flag is written for the report (#6). The book
+is never aborted.
+
+The node self-disables (passes straight through to ``assemble``) when the creator's
+``fidelity_check`` flag is falsy or no STT service is reachable, so existing graph
+runs without an STT service behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+from audify.qa.nodes.report import MAX_BUDGET_PER_CYCLE
+from audify.qa.state import CycleId, FlagEntry, GraphState
+from audify.qa.stt import STTClient, STTServiceError, WhisperSTTClient
+from audify.qa.wer import comparable_reference, word_error_rate
+
+logger = logging.getLogger(__name__)
+
+# Detection thresholds (overridable via creator attributes of the same name).
+WER_THRESHOLD = 0.3
+FIDELITY_WINDOW_S = 8.0
+DURATION_RATIO_THRESHOLD = 0.5
+
+# Duration estimate basis — matches audify/verify.py's narration heuristic.
+WORDS_PER_MINUTE = 75
+
+_CYCLE: CycleId = "cycle_3_retry"
+
+
+def fidelity_node(state: GraphState) -> dict:
+    """Detect truncated episodes and schedule re-chunk retries.
+
+    Returns a dict of updated state channels. ``pending_retry`` drives the
+    conditional back-edge: non-empty → loop back to ``synthesize``.
+    """
+    creator = state["creator"]
+
+    if not getattr(creator, "fidelity_check", False):
+        return {}
+
+    client = _get_stt_client(creator)
+    if client is None:
+        logger.info("Fidelity check skipped: no STT client available.")
+        return {}
+
+    threshold = float(getattr(creator, "wer_threshold", WER_THRESHOLD))
+    window_s = float(getattr(creator, "fidelity_window_s", FIDELITY_WINDOW_S))
+    ratio_threshold = float(
+        getattr(creator, "duration_ratio_threshold", DURATION_RATIO_THRESHOLD)
+    )
+    language = getattr(creator, "resolved_language", None) or getattr(
+        creator, "language", None
+    )
+
+    scripts: dict[int, str] = dict(state["chapter_scripts"])
+    to_check: list[int] = state.get("episodes_to_check", [])
+
+    # Copy nested containers so we never mutate the inbound state in place.
+    retry_budget = {k: dict(v) for k, v in state.get("retry_budget", {}).items()}
+    best_wer = dict(state.get("best_wer", {}))
+    flags = {k: list(v) for k, v in state.get("flags", {}).items()}
+
+    pending_retry: list[int] = []
+
+    for episode_number in to_check:
+        script = scripts.get(episode_number)
+        if script is None:
+            continue
+
+        chapter_id = f"chapter_{episode_number}"
+        episode_path = _episode_path(creator, episode_number)
+        if not episode_path.exists():
+            # No audio produced — coverage check (a different cycle) owns this.
+            continue
+
+        try:
+            head_wer, tail_wer = _window_wers(
+                client, episode_path, script, window_s, language
+            )
+        except STTServiceError as exc:
+            logger.warning(
+                "Fidelity check skipped for %s: STT unavailable (%s)",
+                chapter_id,
+                exc,
+            )
+            continue
+
+        ratio = _duration_ratio(episode_path, script)
+        episode_wer = max(head_wer, tail_wer)
+        suspect = (
+            head_wer > threshold
+            or tail_wer > threshold
+            or ratio < ratio_threshold
+        )
+
+        # Track the lowest-WER attempt so we can restore it on exhaustion.
+        if best_wer.get(chapter_id) is None or episode_wer < best_wer[chapter_id]:
+            best_wer[chapter_id] = episode_wer
+            _save_best_candidate(creator, episode_number, episode_path)
+
+        budget = retry_budget.setdefault(chapter_id, {})
+        retried_before = _CYCLE in budget
+
+        if not suspect:
+            # Episode passes. If it had been retried, record a resolved flag once.
+            if retried_before and not _has_cycle_flag(flags, chapter_id):
+                _append_flag(
+                    flags,
+                    chapter_id,
+                    reason=(
+                        f"WER {episode_wer:.2f} within {threshold:.2f} "
+                        "after re-chunk"
+                    ),
+                    exhausted=False,
+                )
+            continue
+
+        remaining = budget.get(_CYCLE, MAX_BUDGET_PER_CYCLE)
+        reason = _suspect_reason(head_wer, tail_wer, ratio, threshold, ratio_threshold)
+        if remaining > 0:
+            budget[_CYCLE] = remaining - 1
+            pending_retry.append(episode_number)
+            logger.info(
+                "Fidelity flagged %s (%s); scheduling re-chunk retry "
+                "(%d attempt(s) left).",
+                chapter_id,
+                reason,
+                remaining - 1,
+            )
+        else:
+            # Budget exhausted: keep the best attempt, write an exhausted flag.
+            _restore_best_candidate(creator, episode_number, episode_path)
+            _append_flag(
+                flags,
+                chapter_id,
+                reason=(
+                    f"WER {best_wer[chapter_id]:.2f} exceeds {threshold:.2f} "
+                    f"after {MAX_BUDGET_PER_CYCLE} attempts"
+                ),
+                exhausted=True,
+            )
+            logger.warning(
+                "Fidelity check exhausted for %s; keeping best-effort "
+                "artifact (WER %.2f).",
+                chapter_id,
+                best_wer[chapter_id],
+            )
+
+    return {
+        "retry_budget": retry_budget,
+        "best_wer": best_wer,
+        "flags": flags,
+        "pending_retry": pending_retry,
+    }
+
+
+def fidelity_route(state: GraphState) -> str:
+    """Conditional edge: loop back to ``synthesize`` while retries are pending."""
+    return "synthesize" if state.get("pending_retry") else "assemble"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_stt_client(creator: Any) -> Optional[STTClient]:
+    """Return the creator's injected STT client, or build one from env.
+
+    Returns ``None`` only when client construction itself fails — a reachable
+    service is not verified here (per-call errors degrade gracefully instead).
+    """
+    injected = getattr(creator, "stt_client", None)
+    if injected is not None:
+        return injected  # type: ignore[return-value]
+    try:
+        base_url = os.getenv("STT_BASE_URL", "http://localhost:8888")
+        return WhisperSTTClient(base_url=base_url)
+    except Exception as exc:  # pragma: no cover - construction is trivial
+        logger.warning("Could not build STT client: %s", exc)
+        return None
+
+
+def _episode_path(creator: Any, episode_number: int) -> Path:
+    return Path(creator.episodes_path) / f"episode_{episode_number:03d}.mp3"
+
+
+def _best_candidate_path(creator: Any, episode_number: int) -> Path:
+    # Stored under a subdirectory so it is never picked up by the
+    # ``episode_*.mp3`` glob that create_m4b uses to assemble the book.
+    cache = Path(creator.episodes_path) / ".fidelity_best"
+    return cache / f"episode_{episode_number:03d}.mp3"
+
+
+def _save_best_candidate(creator: Any, episode_number: int, source: Path) -> None:
+    dest = _best_candidate_path(creator, episode_number)
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+    except OSError as exc:
+        logger.warning("Could not cache best fidelity candidate: %s", exc)
+
+
+def _restore_best_candidate(
+    creator: Any, episode_number: int, dest: Path
+) -> None:
+    src = _best_candidate_path(creator, episode_number)
+    if not src.exists():
+        return
+    try:
+        shutil.copy2(src, dest)
+    except OSError as exc:
+        logger.warning("Could not restore best fidelity candidate: %s", exc)
+
+
+def _window_wers(
+    client: STTClient,
+    episode_path: Path,
+    script: str,
+    window_s: float,
+    language: Optional[str],
+) -> tuple[float, float]:
+    """Return ``(head_wer, tail_wer)`` for the episode's boundary windows."""
+    from audify.utils.audio import AudioProcessor
+
+    duration = AudioProcessor.get_duration(episode_path)
+    if duration <= 0:
+        # Undecodable / empty audio is a total failure of both windows.
+        return 1.0, 1.0
+
+    window = min(window_s, duration)
+
+    head_hyp = client.transcribe(
+        episode_path, start_s=0.0, end_s=window, language=language
+    )
+    tail_hyp = client.transcribe(
+        episode_path,
+        start_s=max(duration - window_s, 0.0),
+        end_s=duration,
+        language=language,
+    )
+
+    head_wer = word_error_rate(
+        comparable_reference(script, head_hyp, side="head"), head_hyp
+    )
+    tail_wer = word_error_rate(
+        comparable_reference(script, tail_hyp, side="tail"), tail_hyp
+    )
+    return head_wer, tail_wer
+
+
+def _duration_ratio(episode_path: Path, script: str) -> float:
+    """Actual audio seconds / expected seconds from script word count."""
+    from audify.utils.audio import AudioProcessor
+
+    word_count = len(script.split())
+    expected_minutes = max(word_count / WORDS_PER_MINUTE, 1)
+    expected_s = expected_minutes * 60
+    actual_s = AudioProcessor.get_duration(episode_path)
+    return actual_s / expected_s if expected_s else 0.0
+
+
+def _suspect_reason(
+    head_wer: float,
+    tail_wer: float,
+    ratio: float,
+    threshold: float,
+    ratio_threshold: float,
+) -> str:
+    parts = []
+    if head_wer > threshold:
+        parts.append(f"head WER {head_wer:.2f}")
+    if tail_wer > threshold:
+        parts.append(f"tail WER {tail_wer:.2f}")
+    if ratio < ratio_threshold:
+        parts.append(f"duration ratio {ratio:.2f}")
+    return ", ".join(parts) or "below thresholds"
+
+
+def _has_cycle_flag(flags: dict[str, list[FlagEntry]], chapter_id: str) -> bool:
+    return any(
+        entry["cycle"] == _CYCLE for entry in flags.get(chapter_id, [])
+    )
+
+
+def _append_flag(
+    flags: dict[str, list[FlagEntry]],
+    chapter_id: str,
+    *,
+    reason: str,
+    exhausted: bool,
+) -> None:
+    entry: FlagEntry = {
+        "cycle": "cycle_3_retry",
+        "reason": reason,
+        "exhausted": exhausted,
+    }
+    flags.setdefault(chapter_id, []).append(entry)

--- a/audify/qa/nodes/synthesize.py
+++ b/audify/qa/nodes/synthesize.py
@@ -2,15 +2,35 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any, Optional
 
-from audify.qa.state import GraphState
+from audify.qa.nodes.report import MAX_BUDGET_PER_CYCLE
+from audify.qa.state import CycleId, GraphState
 from audify.text_to_speech import TTSSynthesisError
 
 logger = logging.getLogger(__name__)
 
+# Floor for the re-chunk batch size so shrinking never collapses to zero.
+MIN_BATCH_CHARS = 200
+
+_CYCLE: CycleId = "cycle_3_retry"
+
 
 def synthesize_node(state: GraphState) -> dict:
-    """Synthesize TTS audio for every script (Phase 3 of the legacy pipeline)."""
+    """Synthesize TTS audio for every script (Phase 3 of the legacy pipeline).
+
+    Two modes of operation:
+
+    * **First pass** (``pending_retry`` empty): synthesize every script and mark
+      all episodes for the fidelity check.
+    * **Retry pass** (``pending_retry`` populated by the cycle-3 fidelity edge):
+      re-synthesize *only* the flagged episodes with a smaller TTS batch size
+      (re-chunk), and mark just those episodes for re-evaluation.
+    """
+    pending_retry = state.get("pending_retry", [])
+    if pending_retry:
+        return _resynthesize(state, pending_retry)
+
     creator = state["creator"]
     chapter_scripts = state["chapter_scripts"]
     chapter_titles = state["chapter_titles"]
@@ -46,4 +66,87 @@ def synthesize_node(state: GraphState) -> dict:
             )
             raise
 
-    return {"episode_paths": episode_paths}
+    return {
+        "episode_paths": episode_paths,
+        "episodes_to_check": [n for n, _ in chapter_scripts],
+    }
+
+
+def _resynthesize(state: GraphState, pending_retry: list[int]) -> dict:
+    """Re-synthesize the flagged episodes with a smaller batch size.
+
+    Episode file paths are deterministic (``episode_NNN.mp3``), so the global
+    ``episode_paths`` list is unchanged; only the audio behind those paths is
+    regenerated. Returns the re-synthesized episode numbers as the next
+    ``episodes_to_check`` and clears ``pending_retry``.
+    """
+    creator = state["creator"]
+    scripts = dict(state["chapter_scripts"])
+    retry_budget = state.get("retry_budget", {})
+    base = _tts_base_length(creator)
+
+    creator.progress.set_phase("Synthesizing")
+
+    for episode_number in pending_retry:
+        script = scripts.get(episode_number)
+        if script is None:
+            continue
+
+        chapter_id = f"chapter_{episode_number}"
+        remaining = retry_budget.get(chapter_id, {}).get(
+            _CYCLE, MAX_BUDGET_PER_CYCLE
+        )
+        # Attempts already spent → shrink the batch geometrically each retry.
+        attempt = MAX_BUDGET_PER_CYCLE - remaining
+        max_text_length = (
+            max(base // (attempt + 1), MIN_BATCH_CHARS) if base else None
+        )
+
+        _remove_stale_audio(creator, episode_number)
+
+        try:
+            episode_path = creator.synthesize_episode(
+                script, episode_number, max_text_length=max_text_length
+            )
+        except TTSSynthesisError:
+            raise
+        except Exception as e:
+            logger.error(
+                f"Error re-synthesizing Episode {episode_number}: {e}",
+                exc_info=True,
+            )
+            raise
+
+        if episode_path.exists():
+            logger.info(
+                f"Re-synthesized Episode {episode_number} "
+                f"(batch≤{max_text_length} chars): {episode_path}"
+            )
+        else:
+            logger.warning(f"Re-synthesis produced no audio for {episode_number}")
+
+    return {"episodes_to_check": list(pending_retry), "pending_retry": []}
+
+
+def _tts_base_length(creator: Any) -> Optional[int]:
+    """Best-effort read of the provider's default batch size (chars)."""
+    try:
+        return int(creator._get_tts_config().max_text_length)
+    except Exception:
+        return None
+
+
+def _remove_stale_audio(creator: Any, episode_number: int) -> None:
+    """Delete the stale episode artifacts so synthesize_episode regenerates.
+
+    ``synthesize_episode`` early-returns when the MP3 already exists, so the
+    retry must clear it (and the intermediate WAV) first.
+    """
+    episodes_path = Path(creator.episodes_path)
+    stem = f"episode_{episode_number:03d}"
+    for suffix in (".mp3", ".wav"):
+        path = episodes_path / f"{stem}{suffix}"
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.warning("Could not remove stale %s: %s", path, exc)

--- a/audify/qa/state.py
+++ b/audify/qa/state.py
@@ -81,3 +81,11 @@ class GraphState(TypedDict):
     best_wer: dict[str, float]
     # flags[chapter_id] = ordered list of FlagEntry raised against the chapter
     flags: dict[str, list[FlagEntry]]
+    # episode numbers the cycle-3 fidelity check scheduled for re-synthesis on
+    # the next ``synthesize`` visit. Empty on the first pass; populated by the
+    # back-edge and cleared once ``synthesize`` consumes it.
+    pending_retry: list[int]
+    # episode numbers the next ``fidelity`` visit should evaluate. Set by
+    # ``synthesize`` to all episodes on the first pass, and to just the
+    # re-synthesized episodes on a retry pass.
+    episodes_to_check: list[int]

--- a/audify/qa/wer.py
+++ b/audify/qa/wer.py
@@ -1,0 +1,102 @@
+"""Word Error Rate (WER) helpers for the boundary-sampling fidelity check.
+
+The cycle-3 fidelity detector (issue #38) compares a short STT transcript of an
+episode's head/tail window against the corresponding opening/closing words of the
+*script* that was fed to TTS. A high WER on either window indicates the chapter was
+likely truncated.
+
+Implemented with a small word-level Levenshtein distance — no extra dependency.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["normalize_words", "word_error_rate", "comparable_reference"]
+
+# Keep apostrophes inside words ("don't"), drop everything else that is not a
+# word character or whitespace, then split on whitespace.
+_PUNCT_RE = re.compile(r"[^\w\s']", flags=re.UNICODE)
+_APOSTROPHE_EDGE_RE = re.compile(r"(^'+|'+$)")
+
+
+def normalize_words(text: str) -> list[str]:
+    """Lowercase *text*, strip punctuation, and split into comparable words.
+
+    Apostrophes are preserved word-internally so contractions survive, but
+    stripped from word edges. Returns an empty list for empty / whitespace text.
+    """
+    if not text:
+        return []
+    lowered = _PUNCT_RE.sub(" ", text.lower())
+    words = []
+    for token in lowered.split():
+        token = _APOSTROPHE_EDGE_RE.sub("", token)
+        if token:
+            words.append(token)
+    return words
+
+
+def _levenshtein(ref: list[str], hyp: list[str]) -> int:
+    """Word-level Levenshtein edit distance between two token lists."""
+    if not ref:
+        return len(hyp)
+    if not hyp:
+        return len(ref)
+
+    previous = list(range(len(hyp) + 1))
+    for i, ref_word in enumerate(ref, start=1):
+        current = [i]
+        for j, hyp_word in enumerate(hyp, start=1):
+            cost = 0 if ref_word == hyp_word else 1
+            current.append(
+                min(
+                    previous[j] + 1,  # deletion
+                    current[j - 1] + 1,  # insertion
+                    previous[j - 1] + cost,  # substitution
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def word_error_rate(reference: str, hypothesis: str) -> float:
+    """Return the word error rate of *hypothesis* against *reference*.
+
+    ``WER = edit_distance(reference_words, hypothesis_words) / len(reference_words)``,
+    clamped to ``[0.0, 1.0]``.
+
+    Edge cases:
+      * empty reference **and** empty hypothesis → ``0.0`` (nothing to carry,
+        nothing carried — a faithful match).
+      * empty reference, non-empty hypothesis → ``1.0`` (total mismatch).
+    """
+    ref_words = normalize_words(reference)
+    hyp_words = normalize_words(hypothesis)
+
+    if not ref_words:
+        return 0.0 if not hyp_words else 1.0
+
+    distance = _levenshtein(ref_words, hyp_words)
+    return min(distance / len(ref_words), 1.0)
+
+
+def comparable_reference(script: str, hypothesis: str, *, side: str) -> str:
+    """Slice the head/tail of *script* to a word span comparable to *hypothesis*.
+
+    Boundary windows transcribe only a few seconds of audio, so the reference
+    must be length-matched to the transcript — otherwise an intact window scores
+    a high WER purely from length mismatch. Returns the first (``side="head"``)
+    or last (``side="tail"``) ``len(hypothesis_words)`` words of the script,
+    normalized. Returns ``""`` when either side is empty.
+    """
+    if side not in ("head", "tail"):
+        raise ValueError(f"side must be 'head' or 'tail', got {side!r}")
+
+    ref_words = normalize_words(script)
+    n = len(normalize_words(hypothesis))
+    if n == 0 or not ref_words:
+        return ""
+
+    span = ref_words[:n] if side == "head" else ref_words[-n:]
+    return " ".join(span)

--- a/audify/text_to_speech.py
+++ b/audify/text_to_speech.py
@@ -233,9 +233,17 @@ class BaseSynthesizer:
         return batches
 
     def _synthesize_with_provider(
-        self, sentences: List[str], output_wav_path: Path
+        self,
+        sentences: List[str],
+        output_wav_path: Path,
+        max_text_length: Optional[int] = None,
     ) -> None:
-        """Synthesize sentences using the configured TTS provider."""
+        """Synthesize sentences using the configured TTS provider.
+
+        *max_text_length* overrides the provider's default batch size when set
+        (used by the cycle-3 retry edge to re-chunk smaller); otherwise the
+        provider's ``max_text_length`` is used.
+        """
         tts_config = self._get_tts_config()
         temp_audio_files: List[Path] = []
         attempted_sentences = 0
@@ -264,8 +272,14 @@ class BaseSynthesizer:
                 )
 
             # Group sentences into batches based on provider's max text length
+            # (or the smaller re-chunk override supplied by the retry edge).
+            batch_length = (
+                max_text_length
+                if max_text_length is not None
+                else tts_config.max_text_length
+            )
             batches = self._batch_sentences(
-                sentences, tts_config.max_text_length, unit=tts_config.limit_unit
+                sentences, batch_length, unit=tts_config.limit_unit
             )
             logger.info(
                 f"Processing {len(batches)} batch(es) for {len(sentences)} sentences"
@@ -372,11 +386,20 @@ class BaseSynthesizer:
             raise
 
     def _synthesize_sentences(
-        self, sentences: List[str], output_wav_path: Path
+        self,
+        sentences: List[str],
+        output_wav_path: Path,
+        max_text_length: Optional[int] = None,
     ) -> None:
-        """Synthesize a list of sentences into a single WAV file."""
+        """Synthesize a list of sentences into a single WAV file.
+
+        *max_text_length* is forwarded to the provider to override the default
+        batch size (cycle-3 re-chunk); ``None`` keeps the provider default.
+        """
         output_wav_path.parent.mkdir(parents=True, exist_ok=True)
-        self._synthesize_with_provider(sentences, output_wav_path)
+        self._synthesize_with_provider(
+            sentences, output_wav_path, max_text_length=max_text_length
+        )
         logger.info(f"Raw WAV synthesis complete: {output_wav_path}")
 
     def _convert_to_mp3(self, wav_path: Path) -> Path:

--- a/audify/text_to_speech.py
+++ b/audify/text_to_speech.py
@@ -278,6 +278,10 @@ class BaseSynthesizer:
                 if max_text_length is not None
                 else tts_config.max_text_length
             )
+            if batch_length <= 0:
+                raise ValueError(
+                    f"max_text_length must be > 0, got {batch_length}"
+                )
             batches = self._batch_sentences(
                 sentences, batch_length, unit=tts_config.limit_unit
             )

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,6 +1,6 @@
 # QA Pipeline Graph
 
-Topology of the LangGraph QA pipeline in `full` mode (`read → script_gen → synthesize → assemble → report`).
+Topology of the LangGraph QA pipeline in `full` mode (`read → confirm → script_gen → synthesize → fidelity → assemble → report`).
 
 ```mermaid
 graph TD;
@@ -9,15 +9,18 @@ graph TD;
 	confirm(confirm)
 	script_gen(script_gen)
 	synthesize(synthesize)
+	fidelity(fidelity)
 	assemble(assemble)
 	report(report)
 	__end__([<p>__end__</p>]):::last
 	__start__ --> read;
 	assemble --> report;
 	confirm --> script_gen;
+	fidelity -.-> assemble;
+	fidelity -.-> synthesize;
 	read --> confirm;
 	script_gen --> synthesize;
-	synthesize --> assemble;
+	synthesize --> fidelity;
 	report --> __end__;
 	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
@@ -25,7 +28,11 @@ graph TD;
 
 ```
 
+## Cycle 3 — fidelity retry edge
+
+`fidelity` boundary-samples each freshly-synthesized episode (head/tail STT round-trip + duration ratio). When it suspects TTS truncation it loops back to `synthesize` to re-chunk the offending episode on a smaller batch size, bounded to 3 retries per chapter (the `fidelity → synthesize` back-edge above). On exhaustion the lowest-WER attempt is kept and the chapter is flagged in the report; the run never aborts.
+
 ## Sub-graphs
 
 * **`process` mode** (`--process-only`): `read → confirm → script_gen → report → END` — no TTS, no M4B.
-* **`synthesize` mode** (`--synthesize-only`): `load_scripts → synthesize → assemble → report → END` — scripts are loaded from a previous `--process-only` run.
+* **`synthesize` mode** (`--synthesize-only`): `load_scripts → synthesize → fidelity → assemble → report → END` — scripts are loaded from a previous `--process-only` run; the cycle-3 retry edge applies here too.

--- a/tests/test_audiobook_creator.py
+++ b/tests/test_audiobook_creator.py
@@ -729,7 +729,9 @@ class TestAudiobookCreatorSynthesizeEpisode:
             result = creator.synthesize_episode("Script text", 1)
 
             assert result == mp3_path
-            mock_synth.assert_called_once_with(sentences, wav_path)
+            mock_synth.assert_called_once_with(
+                sentences, wav_path, max_text_length=None
+            )
             mock_convert.assert_called_once_with(wav_path)
 
     @patch("audify.audiobook_creator.AudiobookCreator.__init__", return_value=None)
@@ -774,7 +776,9 @@ class TestAudiobookCreatorSynthesizeEpisode:
             assert result == mp3_path
             # Should call with translated sentences
             expected_translated = ["Primera oración.", "Segunda oración."]
-            mock_synth.assert_called_once_with(expected_translated, wav_path)
+            mock_synth.assert_called_once_with(
+                expected_translated, wav_path, max_text_length=None
+            )
 
     @patch("audify.audiobook_creator.AudiobookCreator.__init__", return_value=None)
     @patch("pathlib.Path.exists")
@@ -810,7 +814,9 @@ class TestAudiobookCreatorSynthesizeEpisode:
 
             # Should use original sentences when translation fails
             assert result == mp3_path
-            mock_synth.assert_called_once_with(sentences, wav_path)
+            mock_synth.assert_called_once_with(
+                sentences, wav_path, max_text_length=None
+            )
 
 
 class TestAudiobookCreatorCreateSeries:

--- a/tests/test_create_audiobook.py
+++ b/tests/test_create_audiobook.py
@@ -56,6 +56,7 @@ class TestGetCreator:
                 prompt_file=None,
                 mode="full",
                 warn_stop=False,
+                fidelity_check=False,
             )
 
     def test_get_creator_pdf(self):
@@ -95,6 +96,7 @@ class TestGetCreator:
                 prompt_file=None,
                 mode="full",
                 warn_stop=False,
+                fidelity_check=False,
                 # Note: max_chapters is not passed to PDF creator
             )
 

--- a/tests/test_qa_graph.py
+++ b/tests/test_qa_graph.py
@@ -37,6 +37,10 @@ def _make_creator(tmp_path: Path, chapters: list[str] | None = None) -> MagicMoc
     # never fires in tests that don't set it explicitly. A MagicMock would
     # otherwise read as truthy here.
     creator.warn_stop = False
+    # Cycle-3 fidelity check is opt-in; keep it off for the skeleton tests so
+    # they don't route through the STT round-trip. A MagicMock attribute would
+    # otherwise read as truthy here. The dedicated fidelity tests below set it.
+    creator.fidelity_check = False
 
     # reader is a non-EpubReader so we get the simple path. Using
     # ``MagicMock(spec=PdfReader)`` gives a durable ``isinstance`` answer
@@ -71,13 +75,30 @@ class TestBuildGraph:
     def test_graph_has_expected_nodes(self):
         graph = build_graph()
         nodes = set(graph.get_graph().nodes)
-        expected = {"read", "script_gen", "synthesize", "assemble", "report"}
+        expected = {
+            "read",
+            "script_gen",
+            "synthesize",
+            "fidelity",
+            "assemble",
+            "report",
+        }
         assert expected.issubset(nodes)
 
-    def test_graph_is_acyclic(self):
-        """The skeleton must have no back-edges — all edges must go forward."""
+    def test_full_graph_has_fidelity_back_edge(self):
+        """Cycle 3: full mode must contain the fidelity → synthesize back-edge."""
         graph = build_graph()
-        node_order = ["read", "script_gen", "synthesize", "assemble", "report"]
+        edges = {(e[0], e[1]) for e in graph.get_graph().edges}
+        assert ("synthesize", "fidelity") in edges
+        assert ("fidelity", "synthesize") in edges, (
+            "cycle-3 retry edge missing: fidelity must be able to loop back "
+            "to synthesize"
+        )
+
+    def test_process_graph_is_acyclic(self):
+        """`process` mode performs no TTS, so it stays a forward-only DAG."""
+        graph = build_graph("process")
+        node_order = ["read", "confirm", "script_gen", "report"]
         rank = {name: i for i, name in enumerate(node_order)}
 
         for edge in graph.get_graph().edges:
@@ -85,7 +106,7 @@ class TestBuildGraph:
             if src in rank and dst in rank:
                 assert rank[src] < rank[dst], (
                     f"Back-edge detected: {src} → {dst}; "
-                    "skeleton must be acyclic."
+                    "process mode must be acyclic."
                 )
 
     def test_process_graph_skips_synthesis(self):
@@ -791,3 +812,236 @@ class TestReportNode:
         assert report["pipeline_status"] == "partial"
         assert report["episodes_synthesised"] == 1
         assert report["chapters_expected"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — boundary-sampling fidelity check + re-chunk retry edge (issue #38)
+# ---------------------------------------------------------------------------
+
+
+class _FileBackedSTT:
+    """STT stub that 'transcribes' the text written into the episode file.
+
+    The head window returns the first few words of the file content, the tail
+    window the last few. Because a truncated episode's file is missing its
+    tail, the tail-window transcript will not match the script's closing words.
+    """
+
+    def __init__(self, window_words: int = 4):
+        self.window_words = window_words
+        self.calls: list[tuple] = []
+
+    def transcribe(self, audio_path, *, start_s=None, end_s=None, language=None):
+        self.calls.append((Path(audio_path).name, start_s, end_s))
+        words = Path(audio_path).read_text().split()
+        if start_s == 0.0:  # head window
+            return " ".join(words[: self.window_words])
+        return " ".join(words[-self.window_words :])  # tail window
+
+
+class _RaisingSTT:
+    """STT stub that is always unreachable (exercises graceful degradation)."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def transcribe(self, audio_path, *, start_s=None, end_s=None, language=None):
+        from audify.qa.stt import STTServiceError
+
+        self.calls += 1
+        raise STTServiceError("STT service unreachable")
+
+
+class _FidelityCreator:
+    """Minimal real (non-Mock) creator for synthesize-mode graph runs.
+
+    ``truncate_after`` controls how many synthesis attempts produce truncated
+    audio before full audio is emitted: ``1`` means the first pass truncates
+    and the first re-chunk recovers; a large value means it never recovers.
+    """
+
+    def __init__(self, tmp_path: Path, scripts: dict[int, str], *, truncate_after=1):
+        self.audiobook_path = tmp_path / "out"
+        self.audiobook_path.mkdir(parents=True, exist_ok=True)
+        self.scripts_path = tmp_path / "scripts"
+        self.scripts_path.mkdir(parents=True, exist_ok=True)
+        self.episodes_path = tmp_path / "episodes"
+        self.episodes_path.mkdir(parents=True, exist_ok=True)
+
+        self._scripts = scripts
+        self._titles = [f"Chapter {n}" for n in sorted(scripts)]
+        for n, text in scripts.items():
+            (self.scripts_path / f"episode_{n:03d}_script.txt").write_text(text)
+
+        self.mode = "synthesize"
+        self.fidelity_check = True
+        self.stt_client = _FileBackedSTT()
+        self.language = "en"
+        self.resolved_language = "en"
+        self.warn_stop = False
+        self.progress = MagicMock()
+
+        self._truncate_after = truncate_after
+        self._attempts: dict[int, int] = {}
+        self.synth_calls: list[tuple[int, int | None]] = []
+        self.m4b_calls = 0
+
+    def _verify_tts_provider_available(self):
+        return None
+
+    def _load_chapter_titles(self):
+        return list(self._titles)
+
+    def _get_tts_config(self):
+        cfg = MagicMock()
+        cfg.max_text_length = 4000
+        return cfg
+
+    def synthesize_episode(self, script, episode_number, max_text_length=None):
+        self.synth_calls.append((episode_number, max_text_length))
+        self._attempts[episode_number] = self._attempts.get(episode_number, 0) + 1
+        path = self.episodes_path / f"episode_{episode_number:03d}.mp3"
+        words = script.split()
+        if self._attempts[episode_number] <= self._truncate_after:
+            content = " ".join(words[: len(words) // 2])  # drop the tail
+        else:
+            content = script  # re-chunk restored full fidelity
+        path.write_text(content)
+        return path
+
+    def create_m4b(self):
+        self.m4b_calls += 1
+
+
+# A 20-word script with distinct tokens so head/tail windows are unambiguous.
+_SCRIPT_20 = " ".join(f"word{i:02d}" for i in range(20))
+
+
+@pytest.fixture
+def fixed_duration(monkeypatch):
+    """Pin episode duration so WER (not duration ratio) drives detection."""
+    from audify.utils.audio import AudioProcessor
+
+    monkeypatch.setattr(AudioProcessor, "get_duration", lambda path: 60.0)
+
+
+class TestFidelityCycle:
+    def _load_report(self, creator) -> dict:
+        return json.loads(
+            (Path(creator.audiobook_path) / "quality_report.json").read_text()
+        )
+
+    def test_truncation_triggers_rechunk_retry_and_resolves(
+        self, tmp_path, fixed_duration
+    ):
+        """A truncating first pass fires the cycle; re-chunk resolves it."""
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=1)
+
+        run_graph(creator)
+
+        # Initial synthesis used the provider default (None); the single retry
+        # used a smaller batch size — proving the re-chunk back-edge fired.
+        assert creator.synth_calls == [(1, None), (1, 2000)]
+        assert creator.m4b_calls == 1
+
+        report = self._load_report(creator)
+        chapter = report["chapters"]["chapter_1"]
+        assert chapter["verdict"] == "flagged"
+        assert chapter["attempts_used"]["cycle_3_retry"] == 1
+        assert chapter["best_wer"] == 0.0
+        assert len(chapter["flags"]) == 1
+        flag = chapter["flags"][0]
+        assert flag["cycle"] == "cycle_3_retry"
+        assert flag["exhausted"] is False
+
+        # The re-chunked audio on disk now carries the full script.
+        final = (creator.episodes_path / "episode_001.mp3").read_text()
+        assert final == _SCRIPT_20
+
+    def test_clean_episode_never_triggers_cycle(self, tmp_path, fixed_duration):
+        """An episode that transcribes faithfully raises no flag, no retry."""
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=0)
+
+        run_graph(creator)
+
+        assert creator.synth_calls == [(1, None)]  # no retry
+        report = self._load_report(creator)
+        chapter = report["chapters"]["chapter_1"]
+        assert chapter["verdict"] == "clean"
+        assert chapter["flags"] == []
+
+    def test_exhaustion_keeps_best_effort_and_never_aborts(
+        self, tmp_path, fixed_duration
+    ):
+        """When re-chunk never recovers, budget exhausts but the book completes."""
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=99)
+
+        run_graph(creator)
+
+        # 1 initial attempt + 3 bounded retries.
+        assert len(creator.synth_calls) == 4
+        assert creator.synth_calls[0] == (1, None)
+        assert [mtl for _, mtl in creator.synth_calls[1:]] == [2000, 1333, 1000]
+        # Book is still assembled — the cycle is warn-only.
+        assert creator.m4b_calls == 1
+
+        report = self._load_report(creator)
+        chapter = report["chapters"]["chapter_1"]
+        assert chapter["verdict"] == "unrecoverable"
+        assert chapter["attempts_used"]["cycle_3_retry"] == 3
+        assert chapter["flags"][-1]["exhausted"] is True
+        assert report["verdict_counts"]["unrecoverable"] == 1
+
+    def test_unreachable_stt_degrades_to_passthrough(
+        self, tmp_path, fixed_duration
+    ):
+        """An unreachable STT service skips detection rather than aborting."""
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=1)
+        creator.stt_client = _RaisingSTT()
+
+        run_graph(creator)
+
+        assert creator.synth_calls == [(1, None)]  # no retry attempted
+        assert creator.m4b_calls == 1
+        report = self._load_report(creator)
+        assert report["chapters"]["chapter_1"]["verdict"] == "clean"
+
+    def test_disabled_flag_skips_fidelity(self, tmp_path, fixed_duration):
+        """fidelity_check=False routes straight through to assemble."""
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=1)
+        creator.fidelity_check = False
+
+        run_graph(creator)
+
+        assert creator.synth_calls == [(1, None)]
+        report = self._load_report(creator)
+        assert report["chapters"]["chapter_1"]["verdict"] == "clean"
+
+    def test_duration_ratio_alone_flags_truncation(self, tmp_path, monkeypatch):
+        """Even with WER=0, a short duration ratio corroborates truncation."""
+        from audify.qa.nodes.fidelity import fidelity_node
+        from audify.utils.audio import AudioProcessor
+
+        # Perfect transcripts (file holds the full script) but the audio is far
+        # shorter than the ~16s the 20-word script implies at 75 wpm.
+        monkeypatch.setattr(AudioProcessor, "get_duration", lambda path: 2.0)
+
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=0)
+        episode_path = creator.episodes_path / "episode_001.mp3"
+        episode_path.write_text(_SCRIPT_20)  # full, faithful content
+
+        state = {
+            "creator": creator,
+            "chapter_scripts": [(1, _SCRIPT_20)],
+            "chapter_titles": ["Chapter 1"],
+            "episode_paths": [episode_path],
+            "episodes_to_check": [1],
+            "retry_budget": {},
+            "best_wer": {},
+            "flags": {},
+            "pending_retry": [],
+        }
+
+        out = fidelity_node(state)
+        assert out["pending_retry"] == [1]
+        assert out["retry_budget"]["chapter_1"]["cycle_3_retry"] == 2

--- a/tests/test_qa_wer.py
+++ b/tests/test_qa_wer.py
@@ -1,0 +1,94 @@
+"""Unit tests for the cycle-3 WER helpers (issue #38)."""
+
+from __future__ import annotations
+
+import pytest
+
+from audify.qa.wer import comparable_reference, normalize_words, word_error_rate
+
+
+class TestNormalizeWords:
+    def test_lowercases_and_splits(self):
+        assert normalize_words("The Quick Brown Fox") == [
+            "the",
+            "quick",
+            "brown",
+            "fox",
+        ]
+
+    def test_strips_punctuation_but_keeps_contractions(self):
+        assert normalize_words("Don't stop, now!") == ["don't", "stop", "now"]
+
+    def test_strips_edge_apostrophes(self):
+        assert normalize_words("'quoted' words") == ["quoted", "words"]
+
+    def test_empty(self):
+        assert normalize_words("") == []
+        assert normalize_words("   ") == []
+
+
+class TestWordErrorRate:
+    def test_identical_is_zero(self):
+        assert word_error_rate("hello world", "hello world") == 0.0
+
+    def test_punctuation_and_case_ignored(self):
+        assert word_error_rate("Hello, World!", "hello world") == 0.0
+
+    def test_completely_wrong_is_one(self):
+        assert word_error_rate("alpha beta gamma", "x y z") == 1.0
+
+    def test_single_substitution(self):
+        # one of three words wrong → 1/3
+        assert word_error_rate("a b c", "a x c") == pytest.approx(1 / 3)
+
+    def test_deletion(self):
+        # reference has 4 words, hypothesis drops one → 1/4
+        assert word_error_rate("a b c d", "a b c") == pytest.approx(1 / 4)
+
+    def test_both_empty_is_zero(self):
+        assert word_error_rate("", "") == 0.0
+
+    def test_empty_reference_nonempty_hyp_is_one(self):
+        assert word_error_rate("", "spurious words") == 1.0
+
+    def test_clamped_to_one(self):
+        # many insertions cannot push WER above 1.0
+        assert word_error_rate("a", "a b c d e f g") == 1.0
+
+
+class TestComparableReference:
+    def test_head_matches_hypothesis_length(self):
+        script = "one two three four five six"
+        ref = comparable_reference(script, "ONE two!", side="head")
+        assert ref == "one two"
+
+    def test_tail_matches_hypothesis_length(self):
+        script = "one two three four five six"
+        ref = comparable_reference(script, "five six", side="tail")
+        assert ref == "five six"
+
+    def test_empty_hypothesis_returns_empty(self):
+        assert comparable_reference("a b c", "", side="head") == ""
+
+    def test_empty_script_returns_empty(self):
+        assert comparable_reference("", "a b", side="tail") == ""
+
+    def test_invalid_side(self):
+        with pytest.raises(ValueError, match="side must be"):
+            comparable_reference("a b", "a", side="middle")
+
+    def test_intact_tail_scores_low_wer(self):
+        """A length-matched intact tail window scores ~0 WER."""
+        script = "the chapter ends with these final closing words"
+        tail_transcript = "these final closing words"
+        ref = comparable_reference(script, tail_transcript, side="tail")
+        assert word_error_rate(ref, tail_transcript) == 0.0
+
+    def test_truncated_tail_scores_high_wer(self):
+        """A truncated episode's tail window transcribes earlier content."""
+        script = "the chapter ends with these final closing words"
+        # Audio was cut short, so the "tail" window actually holds mid-chapter
+        # speech that does not match the script's closing words.
+        tail_transcript = "ends with these"
+        ref = comparable_reference(script, tail_transcript, side="tail")
+        assert word_error_rate(ref, tail_transcript) > 0.3

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -817,6 +817,16 @@ def test_cli_single_file_mode_with_prompt_file():
                                 assert result.exit_code == 0
 
 
+def test_cli_fidelity_check_requires_graph():
+    """--fidelity-check without --graph should fail with a clear error."""
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["some-book.epub", "--fidelity-check"])
+    assert result.exit_code == 1
+    assert "--fidelity-check requires --graph" in result.output
+
+
 def test_main_module_import():
     """Test that the main module can be imported."""
     import audify.__main__ as main_module

--- a/tests/test_text_to_speech.py
+++ b/tests/test_text_to_speech.py
@@ -129,6 +129,38 @@ class TestBaseSynthesizer:
         assert mock_tts_config.synthesize.call_count == 2
 
     @patch("audify.text_to_speech.tempfile.TemporaryDirectory")
+    def test_synthesize_non_positive_max_text_length_rejected(self, mock_temp_dir):
+        """A non-positive max_text_length override is rejected before batching."""
+        mock_temp_dir.return_value.name = "/tmp/test_dir"
+
+        synthesizer = BaseSynthesizer(
+            path="test.txt",
+            voice="test_voice",
+            translate=None,
+            save_text=False,
+            language="en",
+        )
+
+        mock_tts_config = MagicMock()
+        mock_tts_config.provider_name = "kokoro"
+        mock_tts_config.is_available.return_value = True
+        mock_tts_config.get_available_voices.return_value = ["test_voice"]
+        mock_tts_config.voice = "test_voice"
+        mock_tts_config.max_text_length = 5000
+        mock_tts_config.limit_unit = "chars"
+
+        with (
+            patch.object(synthesizer, "_get_tts_config", return_value=mock_tts_config),
+            pytest.raises(ValueError, match="max_text_length must be > 0"),
+        ):
+            synthesizer._synthesize_with_provider(
+                ["Hello world"], Path("/tmp/output.wav"), max_text_length=0
+            )
+
+        # Batching never reached, so no synthesis calls were attempted.
+        mock_tts_config.synthesize.assert_not_called()
+
+    @patch("audify.text_to_speech.tempfile.TemporaryDirectory")
     def test_synthesize_kokoro_api_unavailable(self, mock_temp_dir):
         """Test Kokoro API synthesis when API is unavailable."""
         mock_temp_dir.return_value.name = "/tmp/test_dir"


### PR DESCRIPTION
## Summary
- Adds the agentic QA pipeline's **cycle-3 retry edge**: a `fidelity` node runs after `synthesize`, boundary-sampling each episode (head/tail STT round-trip + duration ratio) to detect suspected TTS truncation.
- Flagged chapters loop back to `synthesize` to re-chunk on a smaller batch size, bounded to 3 attempts per chapter. On exhaustion the lowest-WER attempt is kept and the chapter is flagged in the report — the run never aborts.
- Opt-in via `--fidelity-check` (requires `--graph` and the docker-compose STT service); the node self-disables when no STT service is reachable, so existing graph runs are unaffected.

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Implementation notes
- New `audify/qa/nodes/fidelity.py`: detector node + `fidelity_route` conditional edge (loops to `synthesize` while `pending_retry` is non-empty, else `assemble`).
- New `audify/qa/wer.py`: dependency-free word-level Levenshtein WER plus `comparable_reference` for length-matched head/tail script slices.
- `synthesize_node` now handles a retry pass (re-synthesizes only flagged episodes, geometric batch shrink, clears stale audio).
- `GraphState` gains `pending_retry` and `episodes_to_check` channels; graph wires the conditional back-edge in both `full` and `synthesize` modes with an explicit recursion limit.
- `synthesize_episode` / `_synthesize_sentences` / `_synthesize_with_provider` accept an optional `max_text_length` override; threaded through `cli.py` and `convert.py` via the new `--fidelity-check` flag.
- `docs/graph.md` and `README.md` updated to document the retry edge.

## Test plan
- `uv run task test` — format, mypy, and full suite (960 passed, 2 skipped).
- New `tests/test_qa_wer.py` covers WER normalization, edit distance, edge cases, and reference slicing.
- Extended `tests/test_qa_graph.py` covers the fidelity node, retry loop, budget exhaustion, and self-disable paths.

Related to #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental Agentic QA Pipeline with LangGraph-based processing control.
  * Introduced `--fidelity-check` to run boundary-sampling QA (with STT) and automatically re-synthesize potentially truncated chapters.
  * Added generation of `quality_report.json` and recorded per-chapter fidelity outcomes.
  * Fidelity checking now self-disables when the STT service is unreachable.
* **Documentation**
  * Updated Cycle 3 fidelity retry edge docs describing bounded retries and recovery workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->