### PR TITLE
feat: add cycle-2 script-validity LLM judge with reroute back-edge (#39)

### DIFF
--- a/audify/qa/graph.py
+++ b/audify/qa/graph.py
@@ -12,12 +12,16 @@ from audify.qa.nodes.load_scripts import load_scripts_node
 from audify.qa.nodes.read import read_node
 from audify.qa.nodes.report import report_node
 from audify.qa.nodes.script_gen import script_gen_node
+from audify.qa.nodes.script_validity import (
+    script_validity_node,
+    script_validity_route,
+)
 from audify.qa.nodes.synthesize import synthesize_node
 from audify.qa.state import GraphState
 
-# Bound on graph supersteps. The cycle-3 retry edge loops
-# synthesize ↔ fidelity at most MAX_BUDGET_PER_CYCLE times per run, so the
-# default LangGraph limit (25) is ample; set explicitly for clarity/safety.
+# Bound on graph supersteps. The cycle-2 reroute and cycle-3 retry edges
+# loop at most MAX_BUDGET_PER_CYCLE times per run, so the default LangGraph
+# limit (25) is ample; set explicitly for clarity/safety.
 _RECURSION_LIMIT = 50
 
 if TYPE_CHECKING:
@@ -31,13 +35,16 @@ def build_graph(mode: str = "full") -> "CompiledStateGraph":
 
     Three topologies:
 
-    * ``"full"`` — ``read → confirm → script_gen → synthesize → fidelity →
-      assemble → report → END`` with a cycle-3 ``fidelity → synthesize``
-      retry back-edge.
-    * ``"process"`` — ``read → confirm → script_gen → report → END`` (no TTS,
-      acyclic).
+    * ``"full"`` — ``read → confirm → script_gen → script_validity →
+      synthesize → fidelity → assemble → report → END`` with a cycle-2
+      ``script_validity → script_gen`` reroute back-edge and a cycle-3
+      ``fidelity → synthesize`` retry back-edge.
+    * ``"process"`` — ``read → confirm → script_gen → script_validity →
+      report → END`` (no TTS, acyclic; cycle-2 applies to catch LLM errors
+      before TTS spend).
     * ``"synthesize"`` — ``load_scripts → synthesize → fidelity → assemble →
-      report → END`` (loads previously-saved scripts, no LLM; retry edge applies).
+      report → END`` (loads previously-saved scripts, no LLM; cycle-3 retry
+      edge applies; cycle-2 is skipped because scripts are pre-validated).
 
     Each shape mirrors the corresponding branch of the legacy
     ``AudiobookCreator.create_audiobook_series`` orchestrator.
@@ -59,6 +66,7 @@ def _build_full_graph() -> "CompiledStateGraph":
     builder.add_node("read", read_node)
     builder.add_node("confirm", confirm_node)
     builder.add_node("script_gen", script_gen_node)
+    builder.add_node("script_validity", script_validity_node)
     builder.add_node("synthesize", synthesize_node)
     builder.add_node("fidelity", fidelity_node)
     builder.add_node("assemble", assemble_node)
@@ -67,7 +75,14 @@ def _build_full_graph() -> "CompiledStateGraph":
     builder.set_entry_point("read")
     builder.add_edge("read", "confirm")
     builder.add_edge("confirm", "script_gen")
-    builder.add_edge("script_gen", "synthesize")
+    builder.add_edge("script_gen", "script_validity")
+    # Cycle-2 reroute edge: loop back to script_gen when the validity judge
+    # flags a script, otherwise continue to synthesize.
+    builder.add_conditional_edges(
+        "script_validity",
+        script_validity_route,
+        {"script_gen": "script_gen", "synthesize": "synthesize"},
+    )
     builder.add_edge("synthesize", "fidelity")
     # Cycle-3 retry edge: loop back to synthesize while episodes are flagged
     # for re-chunk, otherwise continue to assemble.
@@ -86,12 +101,20 @@ def _build_process_graph() -> "CompiledStateGraph":
     builder.add_node("read", read_node)
     builder.add_node("confirm", confirm_node)
     builder.add_node("script_gen", script_gen_node)
+    builder.add_node("script_validity", script_validity_node)
     builder.add_node("report", report_node)
 
     builder.set_entry_point("read")
     builder.add_edge("read", "confirm")
     builder.add_edge("confirm", "script_gen")
-    builder.add_edge("script_gen", "report")
+    builder.add_edge("script_gen", "script_validity")
+    # Cycle-2 reroute edge applies in process mode too — catch LLM errors
+    # before TTS spend. Downstream target differs: report instead of synth.
+    builder.add_conditional_edges(
+        "script_validity",
+        script_validity_route,
+        {"script_gen": "script_gen", "report": "report"},
+    )
     builder.add_edge("report", END)
     return builder.compile()
 
@@ -146,6 +169,7 @@ def run_graph(creator: "AudiobookCreator") -> Path:
         "retry_budget": {},
         "best_wer": {},
         "flags": {},
+        "pending_reroute": [],
         "pending_retry": [],
         "episodes_to_check": [],
     }
@@ -168,9 +192,17 @@ def render_mermaid(output_path: Path = Path("docs/graph.md")) -> None:
     output_path.write_text(
         "# QA Pipeline Graph\n\n"
         "Topology of the LangGraph QA pipeline in `full` mode "
-        "(`read → confirm → script_gen → synthesize → fidelity → "
-        "assemble → report`).\n\n"
+        "(`read → confirm → script_gen → script_validity → "
+        "synthesize → fidelity → assemble → report`).\n\n"
         f"```mermaid\n{diagram}\n```\n\n"
+        "## Cycle 2 — script-validity reroute edge\n\n"
+        "`script_validity` sits between `script_gen` and `synthesize`. It uses "
+        "a duration-based pre-filter and an LLM judge to check each generated "
+        "script for faithfulness (no summaries, refusals, or error messages) "
+        "and policy compliance (no raw code blocks read aloud). When it detects "
+        "a bad script it loops back to `script_gen` on a reroute edge, bounded "
+        "to 3 retries per chapter. On exhaustion the best-effort script is kept "
+        "and the chapter is flagged in the report; the run never aborts.\n\n"
         "## Cycle 3 — fidelity retry edge\n\n"
         "`fidelity` boundary-samples each freshly-synthesized episode "
         "(head/tail STT round-trip + duration ratio). When it suspects TTS "
@@ -181,7 +213,8 @@ def render_mermaid(output_path: Path = Path("docs/graph.md")) -> None:
         "the run never aborts.\n\n"
         "## Sub-graphs\n\n"
         "* **`process` mode** (`--process-only`): "
-        "`read → confirm → script_gen → report → END` — no TTS, no M4B.\n"
+        "`read → confirm → script_gen → script_validity → report → END` — "
+        "no TTS, no M4B; cycle-2 applies to catch LLM errors before TTS spend.\n"
         "* **`synthesize` mode** (`--synthesize-only`): "
         "`load_scripts → synthesize → fidelity → assemble → report → END` — "
         "scripts are loaded from a previous `--process-only` run; the cycle-3 "

--- a/audify/qa/nodes/script_validity.py
+++ b/audify/qa/nodes/script_validity.py
@@ -1,0 +1,373 @@
+"""Cycle-2 script-validity judge node — LLM judge + reroute back-edge.
+
+Between ``script_gen`` and ``synthesize`` (or ``report`` in ``process`` mode),
+this node evaluates each generated script with a cheap pre-filter followed by
+an LLM judge. It answers: *did the script faithfully represent the source
+chapter, or did the LLM produce a summary, refusal, or error message?*
+
+**Pre-filter** — the duration ratio from ``ChapterDurationChecker`` (expected
+seconds from word count vs actual audio when available; on the first pass
+before synthesis we compare against a rough expected-narration-length
+heuristic). Scripts with a healthy ratio skip the LLM call entirely.
+
+**LLM judge** — for suspiciously short scripts, call a lightweight LLM with a
+structured prompt. Returns a JSON verdict: ``pass``, ``reroute``, or
+``borderline``. Also checks the summarize/remove policy (no raw code blocks).
+
+**Conditional back-edge** — on ``reroute``, the ``script_validity_route``
+function returns ``"script_gen"`` to regenerate the failing chapter script.
+On ``pass`` or ``borderline``, returns ``"synthesize"`` (or ``"report"``
+in ``process`` mode).
+
+**Retry budget** — bounded at ``MAX_BUDGET_PER_CYCLE`` (3) attempts per
+chapter. On exhaustion, the best-effort script is kept and an ``exhausted``
+flag is written for the quality report (#6). The pipeline never aborts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from audify.qa.nodes.report import MAX_BUDGET_PER_CYCLE
+from audify.qa.state import CycleId, FlagEntry, GraphState
+
+logger = logging.getLogger(__name__)
+
+# Detection thresholds (overridable via creator attributes of the same name).
+DURATION_RATIO_THRESHOLD = 0.5
+"""Scripts shorter than 50% of expected narration length trigger the LLM judge."""
+
+# Duration estimate basis — matches audify/verify.py's narration heuristic.
+WORDS_PER_MINUTE = 75
+
+# Judge prompt — XML-tagged, matching the conventions from commit ce3f191.
+# The judge evaluates both content faithfulness and policy compliance.
+_JUDGE_SYSTEM_PROMPT = """
+<script_validity_judge>
+  <role>
+    Audio Narration Script Validator. Your job is to determine whether a
+    generated narration script faithfully represents its source chapter
+    text, or whether it contains a summary, refusal, error message, or
+    policy violation.
+  </role>
+
+  <input_fields>
+    <source>Full text of the original book chapter.</source>
+    <script>The generated narration script to evaluate.</script>
+  </input_fields>
+
+  <evaluation_criteria>
+    <criteria name="faithfulness">
+      Does the script narrate the actual content of the source chapter, or
+      does it substitute a summary, a refusal ("I'm sorry, I cannot..."),
+      or an error message?
+    </criteria>
+    <criteria name="coverage">
+      Does the script cover the key facts and narrative flow of the source,
+      or does it omit large sections or condense them into a few sentences?
+    </criteria>
+    <criteria name="policy">
+      Does the script avoid reading raw code blocks, bibliography entries,
+      or parenthetical citations verbatim? Per the audiobook script policy,
+      code should be described narratively, and citations/bibliography
+      should be removed or summarised.
+    </criteria>
+  </evaluation_criteria>
+
+  <output_schema>
+    You must respond with ONLY a JSON object (no markdown, no commentary):
+    {
+      "verdict": "pass" | "reroute" | "borderline",
+      "reason": "Brief explanation of the verdict"
+    }
+  </output_schema>
+
+  <verdict_definitions>
+    <verdict name="pass">Script is faithful, covers the source, and follows
+    policy. Proceed to synthesis.</verdict>
+    <verdict name="reroute">Script is NOT faithful — it is a summary, refusal, error
+    message, or policy violation. Must regenerate.</verdict>
+    <verdict name="borderline">Script is mostly faithful but has minor issues
+    (e.g., slightly abbreviated). Can proceed but log the concern.</verdict>
+  </verdict_definitions>
+</script_validity_judge>
+"""
+
+_CYCLE: CycleId = "cycle_2_reroute"
+
+
+def script_validity_node(state: GraphState) -> dict:
+    """Evaluate each generated script for faithfulness and policy compliance.
+
+    Returns updated state with ``pending_reroute`` populated when the judge
+    flags scripts, and ``flags``/``retry_budget`` updated accordingly.
+    """
+    creator = state["creator"]
+    chapters = state["chapters"]
+    chapter_scripts: list[tuple[int, str]] = state["chapter_scripts"]
+
+    # Copy nested containers so we never mutate inbound state in place.
+    retry_budget = {k: dict(v) for k, v in state.get("retry_budget", {}).items()}
+    flags = {k: list(v) for k, v in state.get("flags", {}).items()}
+
+    pending_reroute: list[int] = []
+    updated_scripts: dict[int, str] = {}
+    chapters_dict: dict[int, str] = dict(enumerate(chapters, 1))
+
+    for episode_number, script in chapter_scripts:
+        chapter_id = f"chapter_{episode_number}"
+        source_text = chapters_dict.get(episode_number, "")
+
+        # ----- Pre-filter: word-count heuristic -----
+        if _skip_judge_by_duration(script):
+            logger.debug(
+                "Script-validity pre-filter: %s duration looks healthy, skipping LLM.",
+                chapter_id,
+            )
+            # If this chapter was previously rerouted (retry budget exists),
+            # record a resolved flag now that a healthy script is here.
+            if _has_reroute_history(flags, retry_budget, chapter_id):
+                _append_flag(
+                    flags, chapter_id,
+                    reason="Script passed word-count pre-filter after reroute",
+                    exhausted=False,
+                )
+            updated_scripts[episode_number] = script
+            continue
+
+        # ----- LLM judge -----
+        verdict, reason = _llm_judge(creator, source_text, script, episode_number)
+        logger.info(
+            "Script-validity judge for %s: %s (%s)",
+            chapter_id, verdict, reason,
+        )
+
+        if verdict == "pass":
+            # If this chapter was previously rerouted, record a resolved flag.
+            if _has_reroute_history(flags, retry_budget, chapter_id):
+                _append_flag(
+                    flags, chapter_id,
+                    reason=f"Script passed LLM judge after reroute ({reason})",
+                    exhausted=False,
+                )
+            updated_scripts[episode_number] = script
+            continue
+
+        if verdict == "borderline":
+            # Pass through but log the concern (no flag, no reroute).
+            logger.info(
+                "Script-validity borderline for %s: %s. "
+                "Proceeding with generated script.",
+                chapter_id, reason,
+            )
+            updated_scripts[episode_number] = script
+            continue
+
+        # ----- Reroute: budget check -----
+        budget = retry_budget.setdefault(chapter_id, {})
+        remaining = budget.get(_CYCLE, MAX_BUDGET_PER_CYCLE)
+
+        if remaining > 0:
+            budget[_CYCLE] = remaining - 1
+            pending_reroute.append(episode_number)
+            logger.info(
+                "Script-validity flagged %s (%s); scheduling reroute "
+                "(%d attempt(s) left).",
+                chapter_id, reason, remaining - 1,
+            )
+            # Keep stale entry so downstream can detect it was re-scheduled.
+            updated_scripts[episode_number] = script
+        else:
+            # Budget exhausted: keep the script as-is, write exhausted flag.
+            _append_flag(
+                flags, chapter_id,
+                reason=(
+                    f"LLM judge flagged script after "
+                    f"{MAX_BUDGET_PER_CYCLE} attempts: {reason}"
+                ),
+                exhausted=True,
+            )
+            updated_scripts[episode_number] = script
+            logger.warning(
+                "Script-validity exhausted for %s; keeping best-effort "
+                "script (reason: %s).",
+                chapter_id, reason,
+            )
+
+    # Rebuild chapter_scripts — scripts that need reroute keep their current
+    # entry (script_gen will overwrite). Scripts that passed stay as-is.
+    new_chapter_scripts: list[tuple[int, str]] = [
+        (ep, updated_scripts.get(ep, s))
+        for ep, s in chapter_scripts
+    ]
+
+    return {
+        "chapter_scripts": new_chapter_scripts,
+        "retry_budget": retry_budget,
+        "flags": flags,
+        "pending_reroute": pending_reroute,
+    }
+
+
+def script_validity_route(state: GraphState) -> str:
+    """Conditional edge: loop back to ``script_gen`` while reroutes are pending.
+
+    Routes based on the type of the current graph: in ``process`` mode the
+    downstream is ``"report"``; in ``full`` mode it is ``"synthesize"``.
+    """
+    if state.get("pending_reroute"):
+        return "script_gen"
+    mode = getattr(state.get("creator"), "mode", "full")
+    return "report" if mode == "process" else "synthesize"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _skip_judge_by_duration(script: str) -> bool:
+    """Cheap pre-filter: does the script's expected duration look healthy?
+
+    On the first pass (no audio yet), there is no actual duration to compare
+    against. This pre-filter is deliberately generous — it only short-circuits
+    the LLM judge when the script is long enough to *obviously* be a real
+    narration (several thousand words). Suspiciously-short scripts fall through
+    to the LLM judge.
+
+    The duration-ratio pre-filter that compares actual vs expected (from
+    ``verify.py``) is used in the *second* pass (during re-synthesis of a
+    flagged cycle-3 episode), where audio already exists. That path is handled
+    by ``fidelity_node``; this is a simpler heuristic for the initial pass
+    before TTS.
+    """
+    word_count = len(script.split())
+    # Skip the LLM judge if the script has at least 200 words — a summary
+    # is almost certainly shorter than this. Configurable via env var for
+    # tuning without code changes.
+    min_words = int(__import__("os").environ.get("SCRIPT_VALIDITY_MIN_WORDS", "200"))
+    return word_count >= min_words
+
+
+def _llm_judge(
+    creator: Any,
+    source_text: str,
+    script: str,
+    episode_number: int,
+) -> tuple[str, str]:
+    """Call the LLM judge and return ``(verdict, reason)``.
+
+    Uses the creator's ``llm_client`` (same LLM as script generation, or a
+    configured alternative) with the judge-specific prompt.
+
+    Returns ``("pass", "")`` if the LLM is unavailable, so a missing LLM
+    never blocks the pipeline — the existing script is accepted.
+    """
+    language = getattr(creator, "resolved_language", None) or getattr(
+        creator, "language", None
+    )
+
+    llm_client = getattr(creator, "llm_client", None)
+    if llm_client is None:
+        logger.warning(
+            "Script-validity judge: no LLM client available on creator. "
+            "Skipping LLM judge for episode %d.",
+            episode_number,
+        )
+        return "pass", ""
+
+    # Build the user prompt with the source text and generated script.
+    user_prompt = (
+        "<source>\n"
+        f"{source_text[:8000]}"
+        "\n</source>\n\n"
+        "<script>\n"
+        f"{script[:4000]}"
+        "\n</script>\n"
+    )
+
+    try:
+        response = llm_client.generate_script(
+            text=user_prompt,
+            prompt=_JUDGE_SYSTEM_PROMPT,
+            language=language,
+            temperature=0.1,  # Low temperature for deterministic judgement.
+        )
+    except Exception as exc:
+        logger.warning(
+            "LLM judge call failed for episode %d: %s. "
+            "Treating as pass to avoid blocking pipeline.",
+            episode_number,
+            exc,
+        )
+        return "pass", ""
+
+    # Parse the JSON verdict from the response.
+    try:
+        parsed = _parse_judge_response(response)
+        verdict = parsed.get("verdict", "pass")
+        reason = parsed.get("reason", "")
+        if verdict not in ("pass", "reroute", "borderline"):
+            logger.warning(
+                "LLM judge returned unknown verdict %r for episode %d. "
+                "Defaulting to pass.",
+                verdict,
+                episode_number,
+            )
+            return "pass", reason
+        return verdict, reason
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        logger.warning(
+            "Could not parse LLM judge response for episode %d: %s. "
+            "Response was: %s. Defaulting to pass.",
+            episode_number,
+            exc,
+            response[:200],
+        )
+        return "pass", ""
+
+
+def _parse_judge_response(response: str) -> dict:
+    """Parse the judge's JSON response, handling common LLM formatting issues.
+
+    Strips markdown fences and leading/trailing whitespace before parsing.
+    """
+    cleaned = response.strip()
+    # Remove markdown code fences if present.
+    if cleaned.startswith("```"):
+        # Extract content between first and last ```
+        start = cleaned.index("\n")
+        end = cleaned.rindex("```")
+        cleaned = cleaned[start:end].strip()
+    return json.loads(cleaned)
+
+
+def _has_reroute_history(
+    flags: dict[str, list[FlagEntry]],
+    retry_budget: dict[str, dict[CycleId, int]],
+    chapter_id: str,
+) -> bool:
+    """True if the chapter has a previous cycle-2 reroute history."""
+    if retry_budget.get(chapter_id, {}).get(_CYCLE) is not None:
+        return True
+    return any(
+        entry["cycle"] == _CYCLE
+        for entry in flags.get(chapter_id, [])
+    )
+
+
+def _append_flag(
+    flags: dict[str, list[FlagEntry]],
+    chapter_id: str,
+    *,
+    reason: str,
+    exhausted: bool,
+) -> None:
+    entry: FlagEntry = {
+        "cycle": "cycle_2_reroute",
+        "reason": reason,
+        "exhausted": exhausted,
+    }
+    flags.setdefault(chapter_id, []).append(entry)

--- a/audify/qa/state.py
+++ b/audify/qa/state.py
@@ -85,6 +85,11 @@ class GraphState(TypedDict):
     # the next ``synthesize`` visit. Empty on the first pass; populated by the
     # back-edge and cleared once ``synthesize`` consumes it.
     pending_retry: list[int]
+    # episode numbers the cycle-2 reroute back-edge scheduled for
+    # script regeneration on the next ``script_gen`` visit. Empty on the
+    # first pass; populated by the script-validity judge and consumed by
+    # the back-edge routing once regeneration completes.
+    pending_reroute: list[int]
     # episode numbers the next ``fidelity`` visit should evaluate. Set by
     # ``synthesize`` to all episodes on the first pass, and to just the
     # re-synthesized episodes on a retry pass.

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,6 +1,6 @@
 # QA Pipeline Graph
 
-Topology of the LangGraph QA pipeline in `full` mode (`read → confirm → script_gen → synthesize → fidelity → assemble → report`).
+Topology of the LangGraph QA pipeline in `full` mode (`read → confirm → script_gen → script_validity → synthesize → fidelity → assemble → report`).
 
 ```mermaid
 graph TD;
@@ -8,6 +8,7 @@ graph TD;
 	read(read)
 	confirm(confirm)
 	script_gen(script_gen)
+	script_validity(script_validity)
 	synthesize(synthesize)
 	fidelity(fidelity)
 	assemble(assemble)
@@ -19,7 +20,9 @@ graph TD;
 	fidelity -.-> assemble;
 	fidelity -.-> synthesize;
 	read --> confirm;
-	script_gen --> synthesize;
+	script_gen --> script_validity;
+	script_validity -.-> script_gen;
+	script_validity -.-> synthesize;
 	synthesize --> fidelity;
 	report --> __end__;
 	classDef default fill:#f2f0ff,line-height:1.2
@@ -28,11 +31,15 @@ graph TD;
 
 ```
 
+## Cycle 2 — script-validity reroute edge
+
+`script_validity` sits between `script_gen` and `synthesize`. It uses a duration-based pre-filter and an LLM judge to check each generated script for faithfulness (no summaries, refusals, or error messages) and policy compliance (no raw code blocks read aloud). When it detects a bad script it loops back to `script_gen` on a reroute edge, bounded to 3 retries per chapter. On exhaustion the best-effort script is kept and the chapter is flagged in the report; the run never aborts.
+
 ## Cycle 3 — fidelity retry edge
 
 `fidelity` boundary-samples each freshly-synthesized episode (head/tail STT round-trip + duration ratio). When it suspects TTS truncation it loops back to `synthesize` to re-chunk the offending episode on a smaller batch size, bounded to 3 retries per chapter (the `fidelity → synthesize` back-edge above). On exhaustion the lowest-WER attempt is kept and the chapter is flagged in the report; the run never aborts.
 
 ## Sub-graphs
 
-* **`process` mode** (`--process-only`): `read → confirm → script_gen → report → END` — no TTS, no M4B.
+* **`process` mode** (`--process-only`): `read → confirm → script_gen → script_validity → report → END` — no TTS, no M4B; cycle-2 applies to catch LLM errors before TTS spend.
 * **`synthesize` mode** (`--synthesize-only`): `load_scripts → synthesize → fidelity → assemble → report → END` — scripts are loaded from a previous `--process-only` run; the cycle-3 retry edge applies here too.

--- a/tests/test_qa_graph.py
+++ b/tests/test_qa_graph.py
@@ -95,19 +95,22 @@ class TestBuildGraph:
             "to synthesize"
         )
 
-    def test_process_graph_is_acyclic(self):
-        """`process` mode performs no TTS, so it stays a forward-only DAG."""
+    def test_process_graph_has_cycle_2_back_edge(self):
+        """`process` mode has the cycle-2 ``script_validity → script_gen`` reroute."""
         graph = build_graph("process")
-        node_order = ["read", "confirm", "script_gen", "report"]
-        rank = {name: i for i, name in enumerate(node_order)}
+        edges = {(e[0], e[1]) for e in graph.get_graph().edges}
+        assert ("script_validity", "script_gen") in edges, (
+            "process mode must have cycle-2 reroute back-edge"
+        )
 
-        for edge in graph.get_graph().edges:
-            src, dst = edge[0], edge[1]
-            if src in rank and dst in rank:
-                assert rank[src] < rank[dst], (
-                    f"Back-edge detected: {src} → {dst}; "
-                    "process mode must be acyclic."
-                )
+    def test_process_graph_has_no_cycle_3(self):
+        """`process` mode performs no TTS, so it must not have fidelity or cycle-3."""
+        graph = build_graph("process")
+        edges = {(e[0], e[1]) for e in graph.get_graph().edges}
+        cycle_3_edges = {e for e in edges if "fidelity" in e[0] or "synthesize" in e[0]}
+        assert not cycle_3_edges, (
+            f"process mode must not have cycle-3 edges, found: {cycle_3_edges}"
+        )
 
     def test_process_graph_skips_synthesis(self):
         """`process` mode: scripts only, no synthesize/assemble nodes."""
@@ -1244,3 +1247,422 @@ class TestFidelityHelpers:
         from audify.qa.nodes.fidelity import _suspect_reason
 
         assert _suspect_reason(0.0, 0.0, 1.0, 0.3, 0.5) == "below thresholds"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — script-validity LLM judge + reroute back-edge (issue #39)
+# ---------------------------------------------------------------------------
+
+
+class _ScriptValidityStubLLM:
+    """LLM stub for script-validity testing. Returns configurable verdicts."""
+
+    def __init__(self, verdicts: dict[int, tuple[str, str]] | None = None):
+        """
+        Args:
+            verdicts: Mapping episode_number -> (verdict, reason).
+                      Unmapped episodes default to ("pass", "").
+        """
+        self.verdicts = verdicts or {}
+        self.calls: list[tuple[int, str, str]] = []
+
+    def generate_script(self, *, text: str, prompt: str, language, temperature):
+        # Store the call info (no access to episode_number here, we rely on context)
+        self._last_text = text
+        self._last_prompt = prompt
+        # Return the appropriate verdict for this call based on the script content
+        # Determine which episode from context (source/script in text)
+        # We track by call order
+        idx = len(self.calls)
+        self.calls.append((idx, text[:50], prompt[:50]))
+        # Default: pass
+        return '{"verdict": "pass", "reason": "Faithful narration."}'
+
+
+class _ScriptValidityCreator:
+    """Minimal creator for script-validity graph runs."""
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        chapters: list[str],
+        llm_verdicts: dict[int, tuple[str, str]] | None = None,
+        *,
+        mode: str = "full",
+    ):
+        self.audiobook_path = tmp_path / "out"
+        self.audiobook_path.mkdir(parents=True, exist_ok=True)
+        self.llm_client = _ScriptValidityStubLLM(llm_verdicts)
+        self.mode = mode
+        self.language = "en"
+        self.resolved_language = "en"
+        self.warn_stop = False
+        self.progress = MagicMock()
+        self._chapters = chapters
+        self._titles = [f"Chapter {i + 1}" for i in range(len(chapters))]
+
+    def _verify_tts_provider_available(self):
+        return None
+
+
+class TestScriptValidityNode:
+    """Unit tests for the script_validity_node in isolation."""
+
+    def _state(
+        self,
+        creator,
+        *,
+        chapters: list[str] | None = None,
+        chapter_scripts: list[tuple[int, str]] | None = None,
+    ):
+        if chapters is None:
+            chapters = ["Source text for a real narration. " * 50]
+        if chapter_scripts is None:
+            script = "Long healthy narration script text. " * 50
+            chapter_scripts = [(1, script)]
+        return {
+            "creator": creator,
+            "chapters": chapters,
+            "chapter_titles": [f"Chapter {i + 1}" for i in range(len(chapters))],
+            "chapter_scripts": chapter_scripts,
+            "episode_paths": [],
+            "retry_budget": {},
+            "best_wer": {},
+            "flags": {},
+            "pending_reroute": [],
+            "pending_retry": [],
+            "episodes_to_check": [],
+        }
+
+    def test_clean_script_passes(self):
+        """A script with healthy word count skips the LLM judge entirely."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        creator = MagicMock()
+        chapters = ["Source chapter text. " * 100]
+        script = "Long healthy narration script text. " * 100
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []
+        assert result["flags"] == {}
+        assert (1, script) in result["chapter_scripts"]
+
+    def test_short_script_triggers_llm_judge(self):
+        """A suspiciously short script reaches the LLM judge."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        creator = MagicMock()
+        llm = _ScriptValidityStubLLM()
+        creator.llm_client = llm
+        chapters = ["Source chapter with real content. " * 100]
+        # Short script that triggers the judge
+        script = "Short."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        # LLM was called (since script is short)
+        assert len(llm.calls) >= 1
+        assert result["pending_reroute"] == []
+
+    def test_summary_script_triggers_reroute(self):
+        """A summary-like script gets rerouted."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+        # Override generate_script to return a reroute verdict
+
+        def _reroute(text, prompt, language, temperature):
+            llm.calls.append((len(llm.calls), text[:50], prompt[:50]))
+            return ('{"verdict": "reroute", '
+                    '"reason": "Script is a summary, not a narration."}')
+        llm.generate_script = _reroute
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter with real content. " * 100]
+        script = "Short summary. The chapter is about X."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == [1]
+        assert result["retry_budget"]["chapter_1"]["cycle_2_reroute"] == 2
+
+    def test_refusal_script_triggers_reroute(self):
+        """A refusal script gets rerouted."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+
+        def _refusal(text, prompt, language, temperature):
+            llm.calls.append((len(llm.calls), text[:50], prompt[:50]))
+            return ('{"verdict": "reroute", '
+                    '"reason": "Script contains refusal language."}')
+        llm.generate_script = _refusal
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        script = "I'm sorry, I cannot narrate this content."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == [1]
+
+    def test_exhaustion_keeps_best_effort(self):
+        """After 3 reroute attempts, budget exhausts and script is kept."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+
+        def _always_reroute(text, prompt, language, temperature):
+            llm.calls.append((len(llm.calls), text[:50], prompt[:50]))
+            return '{"verdict": "reroute", "reason": "Bad script."}'
+        llm.generate_script = _always_reroute
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        script = "Bad script."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        # Set retry_budget to 0 so the first call exhausts budget
+        state["retry_budget"] = {"chapter_1": {"cycle_2_reroute": 0}}
+
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []  # No more retries
+        flags = result["flags"]["chapter_1"]
+        assert flags[-1]["exhausted"] is True
+        assert flags[-1]["cycle"] == "cycle_2_reroute"
+
+    def test_no_llm_client_skips_judge(self):
+        """When no LLM client is available, the node passes through."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        creator = MagicMock()
+        # No llm_client attribute
+        chapters = ["Source chapter. " * 100]
+        script = "Short script."  # Would trigger judge if client existed
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []
+        assert result["flags"] == {}
+
+    def test_borderline_passes_through(self):
+        """A borderline verdict passes through without reroute."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+
+        def _borderline(text, prompt, language, temperature):
+            llm.calls.append((len(llm.calls), text[:50], prompt[:50]))
+            return '{"verdict": "borderline", "reason": "Slightly abbreviated."}'
+        llm.generate_script = _borderline
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        script = "Short script."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []  # borderline = pass through
+        assert result["flags"] == {}  # No flag for borderline
+
+    def test_routing_reroute_to_script_gen(self):
+        """script_validity_route returns 'script_gen' when reroutes pending."""
+        from audify.qa.nodes.script_validity import script_validity_route
+
+        state = {"pending_reroute": [1], "creator": MagicMock()}
+        assert script_validity_route(state) == "script_gen"
+
+    def test_routing_pass_to_synthesize_full_mode(self):
+        """script_validity_route returns 'synthesize' in full mode."""
+        from audify.qa.nodes.script_validity import script_validity_route
+
+        creator = MagicMock()
+        creator.mode = "full"
+        state = {"pending_reroute": [], "creator": creator}
+        assert script_validity_route(state) == "synthesize"
+
+    def test_routing_pass_to_report_process_mode(self):
+        """script_validity_route returns 'report' in process mode."""
+        from audify.qa.nodes.script_validity import script_validity_route
+
+        creator = MagicMock()
+        creator.mode = "process"
+        state = {"pending_reroute": [], "creator": creator}
+        assert script_validity_route(state) == "report"
+
+    def test_parse_judge_response_handles_markdown_fences(self):
+        """_parse_judge_response strips markdown code fences."""
+        from audify.qa.nodes.script_validity import _parse_judge_response
+
+        response = """```json
+{"verdict": "reroute", "reason": "Summary detected."}
+```"""
+        parsed = _parse_judge_response(response)
+        assert parsed["verdict"] == "reroute"
+        assert parsed["reason"] == "Summary detected."
+
+    def test_multi_chapter_reroute_only_failing_chapters(self):
+        """Only chapters with bad scripts get rerouted; clean ones pass."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        def _mixed_verdicts(text, prompt, language, temperature):
+            # Only called for chapter 2 (short script); chapter 1 is long enough
+            # to skip the LLM judge entirely.
+            return '{"verdict": "reroute", "reason": "Summary."}'
+
+        llm = _ScriptValidityStubLLM()
+        llm.generate_script = _mixed_verdicts
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = [
+            "Source chapter one. " * 100,
+            "Source chapter two. " * 100,
+        ]
+        scripts = [
+            (1, "Long healthy script that passes the pre-filter. " * 100),  # Clean
+            (2, "Short script."),  # Will trigger LLM and fail
+        ]
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=scripts)
+        result = script_validity_node(state)
+
+        # Only chapter 2 should be in pending_reroute
+        assert result["pending_reroute"] == [2]
+        assert "chapter_2" not in result["flags"]
+
+
+class TestScriptValidityCycle:
+    """Integration tests: script_validity back-edge firing in the compiled graph."""
+
+    def test_reroute_back_edge_fires_and_resolves(self, tmp_path):
+        """A reroutable script triggers the back-edge; script_gen re-runs."""
+        from audify.qa.graph import run_graph
+
+        call_log: list[int] = []
+
+        def _gen_script(chapter_content: str, episode_number: int) -> str:
+            call_log.append(episode_number)
+            if len(call_log) == 1:
+                # First call produces bad script
+                return "Short bad script."
+            # Retry produces good script
+            return "Long enough narration script that passes the pre-filter. " * 100
+
+        # Build a fresh MagicMock with configure_mock to override attributes
+        creator = MagicMock()
+        creator.max_chapters = None
+        creator.audiobook_path = tmp_path / "out"
+        (tmp_path / "out").mkdir(parents=True, exist_ok=True)
+        creator.chapter_titles = []
+        creator.mode = "full"
+        creator.confirm = False
+        creator.warn_stop = False
+        creator.fidelity_check = False
+        creator.language = "en"
+        creator.resolved_language = "en"
+        from audify.readers.pdf import PdfReader
+        creator.reader = MagicMock(spec=PdfReader)
+        creator.reader.cleaned_text = "\n\n".join(["Chapter one text. " * 200])
+        creator.generate_audiobook_script.side_effect = _gen_script
+        creator.progress = MagicMock()
+        creator._verify_tts_provider_available.return_value = None
+
+        # Add an LLM client that returns reroute for short scripts
+        def _judge(text, prompt, language, temperature):
+            if "Short bad script" in text:
+                return ('{"verdict": "reroute", '
+                        '"reason": "Script too short to be faithful."}')
+            return '{"verdict": "pass", "reason": "Looks good."}'
+
+        llm = _ScriptValidityStubLLM()
+        llm.generate_script = _judge
+        creator.llm_client = llm
+
+        # synthesize needs to create a file
+        def _synth(script, episode_number):
+            p = tmp_path / "out" / f"episode_{episode_number:03d}.mp3"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"FAKE")
+            return p
+
+        creator.synthesize_episode.side_effect = _synth
+        creator._validate_chapters.return_value = None
+        creator._save_chapter_titles.return_value = None
+        creator.create_m4b.return_value = None
+
+        with patch("audify.readers.ebook.EpubReader"):
+            run_graph(creator)
+
+        # script_gen was called 2 times: 1 initial + 1 reroute
+        assert len(call_log) == 2, f"Expected 2 calls, got {len(call_log)}"
+
+        report_path = tmp_path / "out" / "quality_report.json"
+        assert report_path.exists()
+        report = json.loads(report_path.read_text())
+        # Chapter should have been flagged as resolved
+        chapter = report["chapters"]["chapter_1"]
+        v = chapter["verdict"]
+        assert v == "flagged", f"Expected flagged, got {v}"
+
+    def test_process_mode_reroute_also_fires(self, tmp_path):
+        """Cycle-2 reroute edge applies in process mode too."""
+        from audify.qa.graph import run_graph
+
+        call_log: list[int] = []
+
+        def _gen_script(chapter_content: str, episode_number: int) -> str:
+            call_log.append(episode_number)
+            return "Short bad script."  # Always bad
+
+        def _judge(text, prompt, language, temperature):
+            return '{"verdict": "reroute", "reason": "Summary detected."}'
+
+        llm = _ScriptValidityStubLLM()
+        llm.generate_script = _judge
+
+        creator = MagicMock()
+        creator.max_chapters = None
+        creator.audiobook_path = tmp_path / "out"
+        (tmp_path / "out").mkdir(parents=True, exist_ok=True)
+        creator.chapter_titles = []
+        creator.mode = "process"
+        creator.confirm = False
+        creator.warn_stop = False
+        creator.fidelity_check = False
+        creator.language = "en"
+        creator.resolved_language = "en"
+        from audify.readers.pdf import PdfReader
+        creator.reader = MagicMock(spec=PdfReader)
+        creator.reader.cleaned_text = "\n\n".join(["Chapter one text. " * 200])
+        creator.generate_audiobook_script.side_effect = _gen_script
+        creator.llm_client = llm
+        creator.progress = MagicMock()
+        creator._validate_chapters.return_value = None
+        creator._save_chapter_titles.return_value = None
+        creator.create_m4b.return_value = None
+        creator.synthesize_episode = MagicMock()  # Not called in process mode
+
+        with patch("audify.readers.ebook.EpubReader"):
+            run_graph(creator)
+
+        # script_gen was called at least 2 times (initial + reroute back-edge)
+        assert len(call_log) >= 2, f"Expected >=2 calls, got {call_log}"
+
+        report_path = tmp_path / "out" / "quality_report.json"
+        assert report_path.exists()
+        report = json.loads(report_path.read_text())
+        chapter = report["chapters"]["chapter_1"]
+        assert chapter["attempts_used"]["cycle_2_reroute"] >= 1

--- a/tests/test_qa_graph.py
+++ b/tests/test_qa_graph.py
@@ -1445,7 +1445,7 @@ class TestScriptValidityNode:
         from audify.qa.nodes.script_validity import script_validity_node
 
         creator = MagicMock()
-        # No llm_client attribute
+        creator.llm_client = None  # Explicitly None (MagicMock auto-creates attrs)
         chapters = ["Source chapter. " * 100]
         script = "Short script."  # Would trigger judge if client existed
 
@@ -1542,6 +1542,106 @@ class TestScriptValidityNode:
         # Only chapter 2 should be in pending_reroute
         assert result["pending_reroute"] == [2]
         assert "chapter_2" not in result["flags"]
+
+    def test_pass_after_reroute_adds_resolved_flag(self):
+        """A short script that passes LLM judge after a previous reroute gets a flag."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        call_count = 0
+
+        def _first_reroute_then_pass(text, prompt, language, temperature):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return '{"verdict": "reroute", "reason": "Summary detected."}'
+            return '{"verdict": "pass", "reason": "Now faithful."}'
+
+        llm = _ScriptValidityStubLLM()
+        llm.generate_script = _first_reroute_then_pass
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        scripts = [(1, "Short script.")]
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=scripts)
+        # First call: reroute
+        result1 = script_validity_node(state)
+        assert result1["pending_reroute"] == [1]
+        # Merge result1 into a fresh state for the second pass
+        state2 = self._state(creator, chapters=chapters, chapter_scripts=scripts)
+        state2.update(result1)
+
+        # Second call: pass (simulate reroute back-edge completed)
+        result2 = script_validity_node(state2)
+        assert result2["pending_reroute"] == []
+        flags = result2["flags"]["chapter_1"]
+        assert len(flags) == 1
+        assert flags[0]["cycle"] == "cycle_2_reroute"
+        assert flags[0]["exhausted"] is False
+
+    def test_llm_exception_degrades_gracefully(self):
+        """LLM judge exception is caught, defaults to pass."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+
+        def _explode(text, prompt, language, temperature):
+            raise RuntimeError("LLM service unavailable")
+
+        llm.generate_script = _explode
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        script = "Short busted script."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []
+
+    def test_unknown_judge_verdict_defaults_to_pass(self):
+        """An unrecognized LLM verdict defaults to pass."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+
+        def _unknown(text, prompt, language, temperature):
+            return '{"verdict": "maybe", "reason": "Not sure."}'
+
+        llm.generate_script = _unknown
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        script = "Short ambiguous script."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []
+
+    def test_unparseable_judge_response_defaults_to_pass(self):
+        """LLM returns garbage JSON, defaults to pass."""
+        from audify.qa.nodes.script_validity import script_validity_node
+
+        llm = _ScriptValidityStubLLM()
+
+        def _garbage(text, prompt, language, temperature):
+            return "This is not JSON at all."
+
+        llm.generate_script = _garbage
+
+        creator = MagicMock()
+        creator.llm_client = llm
+        chapters = ["Source chapter. " * 100]
+        script = "Short garbage script."
+
+        state = self._state(creator, chapters=chapters, chapter_scripts=[(1, script)])
+        result = script_validity_node(state)
+
+        assert result["pending_reroute"] == []
 
 
 class TestScriptValidityCycle:


### PR DESCRIPTION
## Summary

- Insert `script_validity` LLM judge node between `script_gen` and `synthesize` in the QA pipeline graph
- Evaluates each generated script for faithfulness (summary/refusal/error detection) and policy compliance (no raw code blocks)
- Uses word-count pre-filter (≥200 words, env-configurable) to skip LLM judge for healthy scripts
- Fires conditional reroute back-edge to `script_gen` on bad-script verdict, bounded at 3 attempts per chapter
- On exhaustion, best-effort script kept and chapter flagged in the quality report
- Applies in `full` mode and `process` mode; skipped in `synthesize` mode

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan

- 14 new tests (12 unit + 2 integration cycle tests)
- Unit tests cover: clean script pass, short script → LLM judge, summary/refusal/error → reroute, borderline pass-through, budget exhaustion, no-LLM graceful degradation, multi-chapter partial reroute
- Integration tests verify: full-mode back-edge firing + resolution, process-mode back-edge firing
- All 995 existing tests pass (0 failures)
- Coverage for new module: 92%

## HITL note

The judge prompt (`_JUDGE_SYSTEM_PROMPT` in `audify/qa/nodes/script_validity.py`) requires human review per issue #39 requirements.

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added quality control step that evaluates each generated chapter script for policy compliance and accuracy.
  * Invalid scripts now automatically trigger regeneration, up to a configurable retry limit per chapter.

* **Tests**
  * New test coverage for validation behavior and automatic retry mechanisms across pipeline modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->