### PR TITLE
feat: announce chapter titles with a pause before each episode

### DIFF
--- a/audify/audiobook_creator.py
+++ b/audify/audiobook_creator.py
@@ -16,6 +16,7 @@ from audify.translate import translate_sentence
 from audify.utils.api_config import CommercialAPIConfig, OllamaAPIConfig
 from audify.utils.audio import AudioProcessor
 from audify.utils.constants import (
+    CHAPTER_TITLE_PAUSE_MS,
     DEFAULT_TTS_PROVIDER,
     OLLAMA_API_BASE_URL,
     OLLAMA_DEFAULT_MODEL,
@@ -622,12 +623,16 @@ class AudiobookCreator(BaseSynthesizer):
         audiobook_script: str,
         episode_number: int,
         max_text_length: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> Path:
         """Synthesizes a single audiobook episode from script.
 
         *max_text_length* overrides the TTS batch size for this episode (used by
         the cycle-3 retry edge to re-chunk smaller); ``None`` uses the provider
         default.
+
+        *title*, when provided, is spoken at the start of the episode followed
+        by a short pause so the listener knows a new chapter has started.
         """
         logger.info(f"Synthesizing Audiobook Episode {episode_number}...")
         # Use standardized episode file naming (tests expect episode_###.wav)
@@ -679,6 +684,9 @@ class AudiobookCreator(BaseSynthesizer):
             self._synthesize_sentences(
                 sentences, episode_wav_path, max_text_length=max_text_length
             )
+            # Announce the chapter title (with a short pause) so the listener
+            # knows a new chapter has started.
+            self._prepend_title_announcement(title, episode_wav_path)
             return self._convert_to_mp3(episode_wav_path)
         except Exception as e:
             logger.error(
@@ -895,7 +903,9 @@ class AudiobookCreator(BaseSynthesizer):
             self.progress.print_chapter_start(episode_num, chapter_title, text_snippet)
 
             self.progress.set_phase("Synthesizing")
-            episode_path = self.synthesize_episode(audiobook_script, episode_num)
+            episode_path = self.synthesize_episode(
+                audiobook_script, episode_num, title=chapter_title
+            )
 
             if episode_path.exists():
                 episode_paths.append(episode_path)
@@ -1045,7 +1055,9 @@ class AudiobookCreator(BaseSynthesizer):
                 )
 
                 self.progress.set_phase("Synthesizing")
-                episode_path = self.synthesize_episode(audiobook_script, episode_number)
+                episode_path = self.synthesize_episode(
+                    audiobook_script, episode_number, title=chapter_title
+                )
 
                 if episode_path.exists():
                     episode_paths.append(episode_path)
@@ -1448,7 +1460,9 @@ class AudiobookPdfCreator(AudiobookCreator):
                 )
                 return []
 
-            episode_path = self.synthesize_episode(audiobook_script, 1)
+            episode_path = self.synthesize_episode(
+                audiobook_script, 1, title=self.title
+            )
 
             if episode_path.exists():
                 logger.info(f"Successfully created audiobook episode: {episode_path}")
@@ -1682,7 +1696,9 @@ class DirectoryAudiobookCreator:
                     title_audio = AudioSegment.from_mp3(title_audio_path)
                     combined_audio += title_audio
                     # Add a short pause after title
-                    combined_audio += AudioSegment.silent(duration=1000)
+                    combined_audio += AudioSegment.silent(
+                        duration=CHAPTER_TITLE_PAUSE_MS
+                    )
                 except Exception as e:
                     logger.error(f"Error adding title audio: {e}")
 
@@ -1778,7 +1794,9 @@ class DirectoryAudiobookCreator:
             combined_audio = AudioSegment.empty()
             if title_audio_path and title_audio_path.exists():
                 combined_audio += AudioSegment.from_mp3(title_audio_path)
-                combined_audio += AudioSegment.silent(duration=1000)
+                combined_audio += AudioSegment.silent(
+                    duration=CHAPTER_TITLE_PAUSE_MS
+                )
 
             combined_audio += AudioSegment.from_mp3(content_mp3_path)
 

--- a/audify/qa/nodes/fidelity.py
+++ b/audify/qa/nodes/fidelity.py
@@ -30,6 +30,7 @@ from audify.qa.nodes.report import MAX_BUDGET_PER_CYCLE
 from audify.qa.state import CycleId, FlagEntry, GraphState
 from audify.qa.stt import STTClient, STTServiceError, WhisperSTTClient
 from audify.qa.wer import comparable_reference, word_error_rate
+from audify.utils.text import format_title_announcement
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,7 @@ def fidelity_node(state: GraphState) -> dict:
     )
 
     scripts: dict[int, str] = dict(state["chapter_scripts"])
+    chapter_titles: list[str] = state.get("chapter_titles", [])
     to_check: list[int] = state.get("episodes_to_check", [])
 
     # Copy nested containers so we never mutate the inbound state in place.
@@ -92,9 +94,19 @@ def fidelity_node(state: GraphState) -> dict:
             # No audio produced — coverage check (a different cycle) owns this.
             continue
 
+        # The episode audio opens with the spoken chapter-title announcement
+        # (see synthesize_episode), so the head-window reference must include
+        # it — otherwise every announced episode scores a spurious head WER.
+        announcement = (
+            format_title_announcement(chapter_titles[episode_number - 1])
+            if 0 < episode_number <= len(chapter_titles)
+            else ""
+        )
+        reference = f"{announcement} {script}".strip()
+
         try:
             head_wer, tail_wer = _window_wers(
-                client, episode_path, script, window_s, language
+                client, episode_path, reference, window_s, language
             )
         except STTServiceError as exc:
             logger.warning(

--- a/audify/qa/nodes/synthesize.py
+++ b/audify/qa/nodes/synthesize.py
@@ -49,7 +49,9 @@ def synthesize_node(state: GraphState) -> dict:
             creator.progress.print_chapter_start(
                 episode_number, chapter_title, text_snippet
             )
-            episode_path = creator.synthesize_episode(audiobook_script, episode_number)
+            episode_path = creator.synthesize_episode(
+                audiobook_script, episode_number, title=chapter_title
+            )
 
             if episode_path.exists():
                 episode_paths.append(episode_path)
@@ -84,6 +86,7 @@ def _resynthesize(state: GraphState, pending_retry: list[int]) -> dict:
     """
     creator = state["creator"]
     scripts = dict(state["chapter_scripts"])
+    chapter_titles = state.get("chapter_titles", [])
     retry_budget = state.get("retry_budget", {})
     base = _tts_base_length(creator)
 
@@ -93,6 +96,12 @@ def _resynthesize(state: GraphState, pending_retry: list[int]) -> dict:
         script = scripts.get(episode_number)
         if script is None:
             continue
+
+        chapter_title = (
+            chapter_titles[episode_number - 1]
+            if 0 < episode_number <= len(chapter_titles)
+            else None
+        )
 
         chapter_id = f"chapter_{episode_number}"
         remaining = retry_budget.get(chapter_id, {}).get(
@@ -108,7 +117,10 @@ def _resynthesize(state: GraphState, pending_retry: list[int]) -> dict:
 
         try:
             episode_path = creator.synthesize_episode(
-                script, episode_number, max_text_length=max_text_length
+                script,
+                episode_number,
+                max_text_length=max_text_length,
+                title=chapter_title,
             )
         except TTSSynthesisError:
             raise

--- a/audify/text_to_speech.py
+++ b/audify/text_to_speech.py
@@ -22,6 +22,7 @@ from audify.utils.api_config import (
 )
 from audify.utils.audio import AudioProcessor
 from audify.utils.constants import (
+    CHAPTER_TITLE_PAUSE_MS,
     DEFAULT_MODEL,
     DEFAULT_SPEAKER,
     DEFAULT_TTS_PROVIDER,
@@ -34,7 +35,11 @@ from audify.utils.m4b_builder import (
     assemble_m4b,
     write_metadata_header,
 )
-from audify.utils.text import break_text_into_sentences, get_file_name_title
+from audify.utils.text import (
+    break_text_into_sentences,
+    format_title_announcement,
+    get_file_name_title,
+)
 
 # Configure logging
 logger = setup_logging(module_name=__name__)
@@ -410,6 +415,58 @@ class BaseSynthesizer:
         """Converts a WAV file to MP3 and removes the original WAV."""
         return AudioProcessor.convert_wav_to_mp3(wav_path)
 
+    def _prepend_title_announcement(
+        self,
+        title: Optional[str],
+        output_wav_path: Path,
+        pause_ms: int = CHAPTER_TITLE_PAUSE_MS,
+    ) -> None:
+        """Prepend a spoken *title* followed by a short pause to *output_wav_path*.
+
+        Announcing the chapter title (and pausing briefly afterwards) tells the
+        listener a new chapter has started. When translation is enabled the
+        title is translated so the announcement matches the narration language.
+
+        Best-effort: any synthesis or audio-processing failure is logged and
+        leaves the already-synthesized chapter audio untouched.
+        """
+        announcement = format_title_announcement(title or "")
+        if not announcement:
+            return
+        if not output_wav_path.exists():
+            logger.warning(
+                f"Cannot announce title '{title}': "
+                f"{output_wav_path} does not exist."
+            )
+            return
+
+        if self.translate and self.language:
+            try:
+                announcement = translate_sentence(
+                    sentence=announcement,
+                    src_lang=self.language,
+                    tgt_lang=self.translate,
+                    model=self.llm_model,
+                    base_url=self.llm_base_url,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Could not translate title announcement '{title}': {e}. "
+                    "Announcing the original title."
+                )
+
+        title_wav_path = self.tmp_dir / f"title_{output_wav_path.stem}.wav"
+        try:
+            self._synthesize_sentences([announcement], title_wav_path)
+            AudioProcessor.prepend_audio_with_pause(
+                title_wav_path, output_wav_path, pause_ms=pause_ms
+            )
+            logger.info(f"Prepended chapter-title announcement: {announcement}")
+        except Exception as e:
+            logger.warning(f"Skipping title announcement for '{title}': {e}")
+        finally:
+            title_wav_path.unlink(missing_ok=True)
+
     def synthesize(self) -> Path:
         """Abstract method for the main synthesis process."""
         raise NotImplementedError("Subclasses must implement the synthesize method.")
@@ -571,6 +628,14 @@ class EpubSynthesizer(BaseSynthesizer):
                 sentences = break_text_into_sentences(chapter_txt)
 
         self._synthesize_sentences(sentences, chapter_wav_path)
+
+        # Announce the chapter title (with a short pause) so the listener
+        # knows a new chapter has started.
+        chapter_title = str(self.reader.get_chapter_title(chapter_content) or "")
+        self._prepend_title_announcement(
+            chapter_title or f"Chapter {chapter_number}", chapter_wav_path
+        )
+
         return self._convert_to_mp3(chapter_wav_path)
 
     def _calculate_total_duration(self, mp3_files: List[Path]) -> float:

--- a/audify/text_to_speech.py
+++ b/audify/text_to_speech.py
@@ -632,6 +632,8 @@ class EpubSynthesizer(BaseSynthesizer):
         # Announce the chapter title (with a short pause) so the listener
         # knows a new chapter has started.
         chapter_title = str(self.reader.get_chapter_title(chapter_content) or "")
+        if chapter_title == "Unknown":
+            chapter_title = ""
         self._prepend_title_announcement(
             chapter_title or f"Chapter {chapter_number}", chapter_wav_path
         )

--- a/audify/utils/audio.py
+++ b/audify/utils/audio.py
@@ -285,6 +285,42 @@ class AudioProcessor:
             raise
 
     @staticmethod
+    def prepend_audio_with_pause(
+        intro_path: Path,
+        main_path: Path,
+        pause_ms: int = 1000,
+        output_path: Optional[Path] = None,
+    ) -> Path:
+        """Prepend *intro_path* audio plus a silent pause to *main_path*.
+
+        Used to place a spoken chapter-title announcement (followed by a short
+        pause) before the chapter audio. Writes the combined audio to
+        *output_path*, defaulting to overwriting *main_path* in place. The
+        export format is inferred from the destination suffix.
+
+        Args:
+            intro_path: Audio to place first (e.g. the spoken title).
+            main_path: The main audio content.
+            pause_ms: Silence duration between intro and main, in milliseconds.
+            output_path: Destination file; defaults to *main_path*.
+
+        Returns:
+            Path to the combined audio file.
+        """
+        intro = AudioSegment.from_file(str(intro_path))
+        main = AudioSegment.from_file(str(main_path))
+        silence = AudioSegment.silent(
+            duration=max(int(pause_ms), 0), frame_rate=intro.frame_rate
+        )
+        combined = intro + silence + main
+
+        destination = output_path or main_path
+        export_format = destination.suffix.lstrip(".").lower() or "wav"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        combined.export(str(destination), format=export_format)
+        return destination
+
+    @staticmethod
     def create_temp_audio_file(
         file_paths: List[Path],
         output_prefix: str,

--- a/audify/utils/audio.py
+++ b/audify/utils/audio.py
@@ -317,7 +317,16 @@ class AudioProcessor:
         destination = output_path or main_path
         export_format = destination.suffix.lstrip(".").lower() or "wav"
         destination.parent.mkdir(parents=True, exist_ok=True)
-        combined.export(str(destination), format=export_format)
+
+        # Export to a temporary file first, then atomically replace to prevent
+        # corrupting the main audio if the export fails mid-write.
+        temp_dest = destination.with_suffix(f".tmp{destination.suffix}")
+        try:
+            combined.export(str(temp_dest), format=export_format)
+            temp_dest.replace(destination)
+        finally:
+            temp_dest.unlink(missing_ok=True)
+
         return destination
 
     @staticmethod

--- a/audify/utils/constants.py
+++ b/audify/utils/constants.py
@@ -32,6 +32,10 @@ OLLAMA_API_BASE_URL = _get_config("OLLAMA_API_URL", "http://localhost:11434")
 DEFAULT_TTS_PROVIDER = _get_config("TTS_PROVIDER", "kokoro")
 AVAILABLE_TTS_PROVIDERS = ["kokoro", "openai", "aws", "google", "qwen"]
 
+# Silence inserted after the spoken chapter-title announcement (milliseconds),
+# so the listener clearly hears that a new chapter has started.
+CHAPTER_TITLE_PAUSE_MS = int(_get_config("CHAPTER_TITLE_PAUSE_MS", "1000"))
+
 OPENAI_API_KEY = _get_config("OPENAI_API_KEY", "")
 OPENAI_TTS_MODEL = _get_config("OPENAI_TTS_MODEL", "gpt-4o-mini-tts-2025-03-20")
 OPENAI_TTS_VOICE = _get_config("OPENAI_TTS_VOICE", "coral")

--- a/audify/utils/text.py
+++ b/audify/utils/text.py
@@ -128,6 +128,25 @@ def break_text_into_sentences(
     return result
 
 
+def format_title_announcement(title: str) -> str:
+    """Normalize a chapter title into the sentence spoken to announce it.
+
+    Replaces underscores with spaces (file-stem titles), collapses whitespace,
+    and guarantees sentence-final punctuation so the TTS engine reads the title
+    as a complete sentence. Returns an empty string for blank titles.
+
+    Used both by the synthesizers (to build the spoken announcement) and by the
+    QA fidelity check (to build the head-window reference that matches the
+    announced audio).
+    """
+    announcement = " ".join(title.replace("_", " ").split())
+    if not announcement:
+        return ""
+    if announcement[-1] not in ".!?":
+        announcement += "."
+    return announcement
+
+
 def get_audio_duration(file_path: str) -> float:
     """Get audio duration in seconds. Delegates to AudioProcessor.get_duration."""
     return AudioProcessor.get_duration(file_path)

--- a/tests/test_audiobook_creator.py
+++ b/tests/test_audiobook_creator.py
@@ -736,6 +736,66 @@ class TestAudiobookCreatorSynthesizeEpisode:
 
     @patch("audify.audiobook_creator.AudiobookCreator.__init__", return_value=None)
     @patch("pathlib.Path.exists")
+    def test_synthesize_episode_announces_title(self, mock_exists, mock_init):
+        """A provided title is announced before the episode audio."""
+        creator = AudiobookCreator.__new__(AudiobookCreator)
+        creator.episodes_path = Path("/fake/episodes")
+        creator.translate = None
+
+        mp3_path = creator.episodes_path / "episode_001.mp3"
+        wav_path = creator.episodes_path / "episode_001.wav"
+        sentences = ["First sentence."]
+
+        mock_exists.return_value = False
+
+        with (
+            patch.object(
+                creator, "_break_script_into_segments", return_value=sentences
+            ),
+            patch.object(creator, "_synthesize_sentences"),
+            patch.object(
+                creator, "_prepend_title_announcement"
+            ) as mock_announce,
+            patch.object(creator, "_convert_to_mp3", return_value=mp3_path),
+        ):
+            result = creator.synthesize_episode(
+                "Script text", 1, title="Chapter One"
+            )
+
+            assert result == mp3_path
+            mock_announce.assert_called_once_with("Chapter One", wav_path)
+
+    @patch("audify.audiobook_creator.AudiobookCreator.__init__", return_value=None)
+    @patch("pathlib.Path.exists")
+    def test_synthesize_episode_no_title_by_default(self, mock_exists, mock_init):
+        """Without a title the announcement helper receives None (a no-op)."""
+        creator = AudiobookCreator.__new__(AudiobookCreator)
+        creator.episodes_path = Path("/fake/episodes")
+        creator.translate = None
+
+        mp3_path = creator.episodes_path / "episode_001.mp3"
+        wav_path = creator.episodes_path / "episode_001.wav"
+
+        mock_exists.return_value = False
+
+        with (
+            patch.object(
+                creator,
+                "_break_script_into_segments",
+                return_value=["First sentence."],
+            ),
+            patch.object(creator, "_synthesize_sentences"),
+            patch.object(
+                creator, "_prepend_title_announcement"
+            ) as mock_announce,
+            patch.object(creator, "_convert_to_mp3", return_value=mp3_path),
+        ):
+            creator.synthesize_episode("Script text", 1)
+
+            mock_announce.assert_called_once_with(None, wav_path)
+
+    @patch("audify.audiobook_creator.AudiobookCreator.__init__", return_value=None)
+    @patch("pathlib.Path.exists")
     def test_synthesize_episode_with_translation(self, mock_exists, mock_init):
         """Test episode synthesis with translation."""
         creator = AudiobookCreator.__new__(AudiobookCreator)
@@ -1803,6 +1863,7 @@ class TestAudiobookPdfCreator:
         creator.language = "en"
         creator.resolved_language = "en"
         creator.translate = None
+        creator.title = "Test PDF Book"
 
         # Mock PDF reader
         mock_reader = Mock(spec=PdfReader)
@@ -1836,6 +1897,7 @@ class TestAudiobookPdfCreator:
         creator.language = "en"
         creator.resolved_language = "en"
         creator.translate = None
+        creator.title = "Test PDF Book"
 
         # Mock PDF reader
         mock_reader = Mock(spec=PdfReader)
@@ -1906,6 +1968,7 @@ class TestAudiobookPdfCreator:
         creator.language = "en"
         creator.resolved_language = "en"
         creator.translate = None
+        creator.title = "Test PDF Book"
 
         # Mock PDF reader with short text (< 200 words)
         mock_reader = Mock(spec=PdfReader)
@@ -1938,6 +2001,7 @@ class TestAudiobookPdfCreator:
         creator.language = "es"  # Spanish
         creator.resolved_language = "es"
         creator.translate = None
+        creator.title = "Libro de Prueba"
 
         # Mock PDF reader
         mock_reader = Mock(spec=PdfReader)

--- a/tests/test_pipeline_improvements.py
+++ b/tests/test_pipeline_improvements.py
@@ -259,7 +259,7 @@ class TestSynthesizeFromExistingScripts:
             file_name=Path("test"),
         )
 
-        def fake_synthesize(script, num):
+        def fake_synthesize(script, num, **kwargs):
             path = episodes / f"episode_{num:03d}.mp3"
             path.write_bytes(b"fake-mp3")
             return path

--- a/tests/test_qa_graph.py
+++ b/tests/test_qa_graph.py
@@ -18,6 +18,7 @@ from audify.qa.nodes.assemble import assemble_node
 from audify.qa.nodes.script_gen import script_gen_node
 from audify.qa.nodes.synthesize import synthesize_node
 from audify.readers.pdf import PdfReader
+from audify.utils.text import format_title_announcement
 
 
 def _make_creator(tmp_path: Path, chapters: list[str] | None = None) -> MagicMock:
@@ -56,7 +57,7 @@ def _make_creator(tmp_path: Path, chapters: list[str] | None = None) -> MagicMoc
     creator.generate_audiobook_script.side_effect = _gen_script
 
     # synthesize_episode creates a dummy mp3 file
-    def _synth(script: str, episode_number: int) -> Path:
+    def _synth(script: str, episode_number: int, **kwargs) -> Path:
         p = tmp_path / f"episode_{episode_number:03d}.mp3"
         p.write_bytes(b"FAKE")
         return p
@@ -992,6 +993,7 @@ class _FidelityCreator:
         self._truncate_after = truncate_after
         self._attempts: dict[int, int] = {}
         self.synth_calls: list[tuple[int, int | None]] = []
+        self.synth_titles: list[str | None] = []
         self.m4b_calls = 0
 
     def _verify_tts_provider_available(self):
@@ -1005,8 +1007,11 @@ class _FidelityCreator:
         cfg.max_text_length = 4000
         return cfg
 
-    def synthesize_episode(self, script, episode_number, max_text_length=None):
+    def synthesize_episode(
+        self, script, episode_number, max_text_length=None, title=None
+    ):
         self.synth_calls.append((episode_number, max_text_length))
+        self.synth_titles.append(title)
         self._attempts[episode_number] = self._attempts.get(episode_number, 0) + 1
         path = self.episodes_path / f"episode_{episode_number:03d}.mp3"
         words = script.split()
@@ -1014,6 +1019,11 @@ class _FidelityCreator:
             content = " ".join(words[: len(words) // 2])  # drop the tail
         else:
             content = script  # re-chunk restored full fidelity
+        # Mirror production audio: the episode opens with the spoken
+        # chapter-title announcement followed by the narration.
+        announcement = format_title_announcement(title or "")
+        if announcement:
+            content = f"{announcement} {content}"
         path.write_text(content)
         return path
 
@@ -1062,9 +1072,10 @@ class TestFidelityCycle:
         assert flag["cycle"] == "cycle_3_retry"
         assert flag["exhausted"] is False
 
-        # The re-chunked audio on disk now carries the full script.
+        # The re-chunked audio on disk now carries the full script (the
+        # chapter-title announcement is still prepended, as in production).
         final = (creator.episodes_path / "episode_001.mp3").read_text()
-        assert final == _SCRIPT_20
+        assert final == f"Chapter 1. {_SCRIPT_20}"
 
     def test_clean_episode_never_triggers_cycle(self, tmp_path, fixed_duration):
         """An episode that transcribes faithfully raises no flag, no retry."""
@@ -1077,6 +1088,38 @@ class TestFidelityCycle:
         chapter = report["chapters"]["chapter_1"]
         assert chapter["verdict"] == "clean"
         assert chapter["flags"] == []
+
+    def test_title_announcement_does_not_trip_head_window(
+        self, tmp_path, fixed_duration
+    ):
+        """Audio opening with the spoken chapter title passes the head check.
+
+        The synthesize node passes the chapter title through so the episode
+        audio begins with the announcement; the fidelity node must include
+        that announcement in its head-window reference or every announced
+        episode would be flagged as truncated.
+        """
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=0)
+
+        run_graph(creator)
+
+        # The synthesize node passed the chapter title through.
+        assert creator.synth_titles == ["Chapter 1"]
+        # The audio on disk really does open with the announcement.
+        audio_text = (creator.episodes_path / "episode_001.mp3").read_text()
+        assert audio_text.startswith("Chapter 1.")
+        # And the fidelity check still reports the episode as clean.
+        assert creator.synth_calls == [(1, None)]  # no retry scheduled
+        report = self._load_report(creator)
+        assert report["chapters"]["chapter_1"]["verdict"] == "clean"
+
+    def test_title_passed_through_on_rechunk_retry(self, tmp_path, fixed_duration):
+        """The re-chunk retry keeps announcing the chapter title."""
+        creator = _FidelityCreator(tmp_path, {1: _SCRIPT_20}, truncate_after=1)
+
+        run_graph(creator)
+
+        assert creator.synth_titles == ["Chapter 1", "Chapter 1"]
 
     def test_exhaustion_keeps_best_effort_and_never_aborts(
         self, tmp_path, fixed_duration
@@ -1718,7 +1761,7 @@ class TestScriptValidityCycle:
         creator.llm_client = llm
 
         # synthesize needs to create a file
-        def _synth(script, episode_number):
+        def _synth(script, episode_number, **kwargs):
             p = tmp_path / "out" / f"episode_{episode_number:03d}.mp3"
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_bytes(b"FAKE")

--- a/tests/test_text_to_speech.py
+++ b/tests/test_text_to_speech.py
@@ -15,6 +15,7 @@ from audify.text_to_speech import (
     suppress_stdout,
 )
 from audify.utils.api_config import KokoroAPIConfig
+from audify.utils.constants import CHAPTER_TITLE_PAUSE_MS
 
 
 class TestKokoroAPIConfig:
@@ -88,6 +89,114 @@ class TestBaseSynthesizer:
         ):
             result = synthesizer.get_terminal_output()
             assert result == test_content
+
+    def _make_synthesizer(self, tmp_path, translate=None):
+        """Build a BaseSynthesizer whose tmp_dir is a real directory."""
+        with patch(
+            "audify.text_to_speech.tempfile.TemporaryDirectory"
+        ) as mock_temp_dir:
+            mock_temp_dir.return_value.name = str(tmp_path)
+            return BaseSynthesizer(
+                path="test.txt",
+                voice="test_voice",
+                translate=translate,
+                save_text=False,
+                language="en",
+            )
+
+    def test_prepend_title_announcement_success(self, tmp_path):
+        """The title is synthesized and prepended with the default pause."""
+        synthesizer = self._make_synthesizer(tmp_path)
+        output_wav = tmp_path / "chapter_001.wav"
+        output_wav.write_bytes(b"main audio")
+        title_wav = tmp_path / "title_chapter_001.wav"
+
+        def fake_synth(sentences, path, max_text_length=None):
+            path.write_bytes(b"title audio")
+
+        with (
+            patch.object(
+                synthesizer, "_synthesize_sentences", side_effect=fake_synth
+            ) as mock_synth,
+            patch(
+                "audify.text_to_speech.AudioProcessor.prepend_audio_with_pause"
+            ) as mock_prepend,
+        ):
+            synthesizer._prepend_title_announcement("Chapter One", output_wav)
+
+        mock_synth.assert_called_once_with(["Chapter One."], title_wav)
+        mock_prepend.assert_called_once_with(
+            title_wav, output_wav, pause_ms=CHAPTER_TITLE_PAUSE_MS
+        )
+        # The temporary title WAV is cleaned up afterwards.
+        assert not title_wav.exists()
+
+    @pytest.mark.parametrize("title", [None, "", "   "])
+    def test_prepend_title_announcement_blank_title_noop(self, tmp_path, title):
+        """Blank titles never trigger synthesis."""
+        synthesizer = self._make_synthesizer(tmp_path)
+        output_wav = tmp_path / "chapter_001.wav"
+        output_wav.write_bytes(b"main audio")
+
+        with patch.object(synthesizer, "_synthesize_sentences") as mock_synth:
+            synthesizer._prepend_title_announcement(title, output_wav)
+
+        mock_synth.assert_not_called()
+
+    def test_prepend_title_announcement_missing_wav_noop(self, tmp_path):
+        """A missing chapter WAV skips the announcement entirely."""
+        synthesizer = self._make_synthesizer(tmp_path)
+        missing_wav = tmp_path / "chapter_404.wav"
+
+        with patch.object(synthesizer, "_synthesize_sentences") as mock_synth:
+            synthesizer._prepend_title_announcement("Chapter One", missing_wav)
+
+        mock_synth.assert_not_called()
+
+    def test_prepend_title_announcement_failure_keeps_chapter_audio(self, tmp_path):
+        """A TTS failure is swallowed and leaves the chapter audio untouched."""
+        synthesizer = self._make_synthesizer(tmp_path)
+        output_wav = tmp_path / "chapter_001.wav"
+        output_wav.write_bytes(b"main audio")
+
+        with patch.object(
+            synthesizer,
+            "_synthesize_sentences",
+            side_effect=RuntimeError("TTS down"),
+        ):
+            # Must not raise.
+            synthesizer._prepend_title_announcement("Chapter One", output_wav)
+
+        assert output_wav.read_bytes() == b"main audio"
+
+    def test_prepend_title_announcement_translates_title(self, tmp_path):
+        """With translation enabled, the announcement is translated first."""
+        synthesizer = self._make_synthesizer(tmp_path, translate="es")
+        output_wav = tmp_path / "chapter_001.wav"
+        output_wav.write_bytes(b"main audio")
+
+        with (
+            patch.object(synthesizer, "_synthesize_sentences") as mock_synth,
+            patch(
+                "audify.text_to_speech.AudioProcessor.prepend_audio_with_pause"
+            ),
+            patch(
+                "audify.text_to_speech.translate_sentence",
+                return_value="Capítulo Uno.",
+            ) as mock_translate,
+        ):
+            synthesizer._prepend_title_announcement("Chapter One", output_wav)
+
+        mock_translate.assert_called_once_with(
+            sentence="Chapter One.",
+            src_lang="en",
+            tgt_lang="es",
+            model=None,
+            base_url=None,
+        )
+        mock_synth.assert_called_once_with(
+            ["Capítulo Uno."], tmp_path / "title_chapter_001.wav"
+        )
 
     @patch("audify.text_to_speech.tempfile.TemporaryDirectory")
     def test_synthesize_kokoro_success(self, mock_temp_dir):
@@ -524,6 +633,82 @@ class TestEpubSynthesizer:
             assert "chapter_001.mp3" in str(result)
             # Methods may not be called if file already exists
             assert mock_convert is not None
+
+    @patch("audify.text_to_speech.EpubReader")
+    @patch("audify.text_to_speech.tempfile.TemporaryDirectory")
+    @patch("audify.text_to_speech.break_text_into_sentences")
+    def test_synthesize_chapter_announces_title(
+        self, mock_break, mock_temp_dir, mock_epub_reader
+    ):
+        """The chapter title is announced before the chapter audio."""
+        mock_temp_dir.return_value.name = "/tmp/test_dir"
+        mock_epub_reader_instance = MagicMock()
+        mock_epub_reader.return_value = mock_epub_reader_instance
+        mock_epub_reader_instance.get_language.return_value = "en"
+        mock_epub_reader_instance.title = "Test Book"
+        mock_epub_reader_instance.get_cover_image.return_value = None
+        mock_epub_reader_instance.extract_text.return_value = "Chapter content"
+        mock_epub_reader_instance.get_chapter_title.return_value = "The Beginning"
+
+        mock_break.return_value = ["Sentence 1."]
+
+        mock_file = mock_open()
+        with (
+            patch("pathlib.Path.exists", return_value=False),
+            patch("pathlib.Path.mkdir"),
+            patch("builtins.open", mock_file),
+            patch.object(EpubSynthesizer, "_synthesize_sentences"),
+            patch.object(
+                EpubSynthesizer, "_prepend_title_announcement"
+            ) as mock_announce,
+            patch.object(EpubSynthesizer, "_convert_to_mp3") as mock_convert,
+        ):
+            mock_convert.return_value = Path("/tmp/chapter_001.mp3")
+
+            synthesizer = EpubSynthesizer(path="test.epub")
+            synthesizer.synthesize_chapter("chapter content", 1)
+
+            mock_announce.assert_called_once()
+            announced_title = mock_announce.call_args[0][0]
+            assert announced_title == "The Beginning"
+
+    @patch("audify.text_to_speech.EpubReader")
+    @patch("audify.text_to_speech.tempfile.TemporaryDirectory")
+    @patch("audify.text_to_speech.break_text_into_sentences")
+    def test_synthesize_chapter_announces_fallback_title(
+        self, mock_break, mock_temp_dir, mock_epub_reader
+    ):
+        """Chapters without an extractable title announce 'Chapter N'."""
+        mock_temp_dir.return_value.name = "/tmp/test_dir"
+        mock_epub_reader_instance = MagicMock()
+        mock_epub_reader.return_value = mock_epub_reader_instance
+        mock_epub_reader_instance.get_language.return_value = "en"
+        mock_epub_reader_instance.title = "Test Book"
+        mock_epub_reader_instance.get_cover_image.return_value = None
+        mock_epub_reader_instance.extract_text.return_value = "Chapter content"
+        mock_epub_reader_instance.get_chapter_title.return_value = ""
+
+        mock_break.return_value = ["Sentence 1."]
+
+        mock_file = mock_open()
+        with (
+            patch("pathlib.Path.exists", return_value=False),
+            patch("pathlib.Path.mkdir"),
+            patch("builtins.open", mock_file),
+            patch.object(EpubSynthesizer, "_synthesize_sentences"),
+            patch.object(
+                EpubSynthesizer, "_prepend_title_announcement"
+            ) as mock_announce,
+            patch.object(EpubSynthesizer, "_convert_to_mp3") as mock_convert,
+        ):
+            mock_convert.return_value = Path("/tmp/chapter_002.mp3")
+
+            synthesizer = EpubSynthesizer(path="test.epub")
+            synthesizer.synthesize_chapter("chapter content", 2)
+
+            mock_announce.assert_called_once()
+            announced_title = mock_announce.call_args[0][0]
+            assert announced_title == "Chapter 2"
 
     @patch("audify.text_to_speech.EpubReader")
     @patch("audify.text_to_speech.tempfile.TemporaryDirectory")

--- a/tests/utils/test_audio.py
+++ b/tests/utils/test_audio.py
@@ -365,6 +365,55 @@ class TestAudioProcessor:
             assert len(chunks) == 1
             assert chunks[0] == file_paths
 
+    def test_prepend_audio_with_pause_combines_in_order(self, tmp_path):
+        """Intro + silence + main are concatenated, overwriting main in place."""
+        from pydub import AudioSegment
+
+        intro_path = tmp_path / "intro.wav"
+        main_path = tmp_path / "main.wav"
+        AudioSegment.silent(duration=500).export(str(intro_path), format="wav")
+        AudioSegment.silent(duration=1000).export(str(main_path), format="wav")
+
+        result = AudioProcessor.prepend_audio_with_pause(
+            intro_path, main_path, pause_ms=250
+        )
+
+        assert result == main_path
+        combined_ms = len(AudioSegment.from_wav(str(main_path)))
+        assert abs(combined_ms - 1750) <= 10
+
+    def test_prepend_audio_with_pause_custom_output(self, tmp_path):
+        """A custom output path leaves the main audio untouched."""
+        from pydub import AudioSegment
+
+        intro_path = tmp_path / "intro.wav"
+        main_path = tmp_path / "main.wav"
+        output_path = tmp_path / "combined.wav"
+        AudioSegment.silent(duration=500).export(str(intro_path), format="wav")
+        AudioSegment.silent(duration=1000).export(str(main_path), format="wav")
+
+        result = AudioProcessor.prepend_audio_with_pause(
+            intro_path, main_path, pause_ms=500, output_path=output_path
+        )
+
+        assert result == output_path
+        assert abs(len(AudioSegment.from_wav(str(output_path))) - 2000) <= 10
+        # Original main audio is unchanged.
+        assert abs(len(AudioSegment.from_wav(str(main_path))) - 1000) <= 10
+
+    def test_prepend_audio_with_pause_negative_pause_clamped(self, tmp_path):
+        """Negative pauses are clamped to zero silence."""
+        from pydub import AudioSegment
+
+        intro_path = tmp_path / "intro.wav"
+        main_path = tmp_path / "main.wav"
+        AudioSegment.silent(duration=300).export(str(intro_path), format="wav")
+        AudioSegment.silent(duration=700).export(str(main_path), format="wav")
+
+        AudioProcessor.prepend_audio_with_pause(intro_path, main_path, pause_ms=-100)
+
+        assert abs(len(AudioSegment.from_wav(str(main_path))) - 1000) <= 10
+
     def test_create_temp_audio_file_success(self, tmp_path):
         """Test successful creation of temporary audio file."""
         file_paths = [Path("file1.mp3"), Path("file2.mp3")]

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -7,6 +7,7 @@ from audify.utils.text import (
     break_too_long_sentences,
     clean_text,
     combine_small_sentences,
+    format_title_announcement,
     get_audio_duration,
     get_file_extension,
     get_file_name_title,
@@ -80,3 +81,21 @@ def test_get_file_name_title():
     title = "This is a Test Title!"
     expected = "this_is_a_test_title"
     assert get_file_name_title(title) == expected
+
+
+def test_format_title_announcement_adds_final_period():
+    assert format_title_announcement("Chapter One") == "Chapter One."
+
+
+@pytest.mark.parametrize("title", ["What Now?", "Onward!", "The End."])
+def test_format_title_announcement_keeps_existing_punctuation(title):
+    assert format_title_announcement(title) == title
+
+
+def test_format_title_announcement_normalizes_whitespace_and_underscores():
+    assert format_title_announcement("  my_article   title ") == "my article title."
+
+
+@pytest.mark.parametrize("title", ["", "   ", "___"])
+def test_format_title_announcement_blank_titles(title):
+    assert format_title_announcement(title) == ""


### PR DESCRIPTION
## Summary
- Every synthesized chapter/episode now opens with a spoken announcement of its title, followed by a short pause, so listeners get a clear audio cue that a new chapter has started
- The announcement is synthesized through the same TTS pipeline as the narration (and translated first when translation is enabled), then prepended to the chapter's audio with a configurable silence (`CHAPTER_TITLE_PAUSE_MS`, default 1000ms)
- The QA fidelity check's head-window reference now accounts for the announcement, so announced episodes are no longer flagged as truncated at the pipeline's own quality gate
- Failures to synthesize or prepend the announcement are logged and swallowed, leaving the already-synthesized chapter audio untouched

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `uv run ruff check ./audify ./tests --fix` — clean
- `uv run mypy ./audify ./tests --ignore-missing-imports` — clean
- `STT_MOCK=true uv run pytest --cov=audify --cov-report=term-missing` — 1102 passed, 2 skipped
- New/updated coverage: `_prepend_title_announcement` (success, blank title, missing WAV, synthesis failure, translation), `AudioProcessor.prepend_audio_with_pause`, `format_title_announcement`, chapter/episode title propagation through `EpubSynthesizer`, `AudiobookCreator`, `AudiobookPdfCreator`, and the QA graph's synthesize/fidelity nodes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audiobook/EPUB chapter synthesis now starts with a spoken, normalized chapter title announcement.
  * Title announcements are translated when narration language translation is enabled.
  * Added a configurable pause after the title announcement before chapter audio begins.
* **Bug Fixes**
  * Improved QA/fidelity detection so spoken title announcements don’t cause false truncation/mismatch findings.
  * Standardized the title-to-audio pause duration across directory stitching and text aggregation.
* **Tests**
  * Added unit tests covering title formatting, pause handling, translation + fallbacks, and preservation during retries/quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->